### PR TITLE
wiggle the chat input bar when send is blocked by awaiting ai reply

### DIFF
--- a/.changeset/wiggle-on-blocked-send.md
+++ b/.changeset/wiggle-on-blocked-send.md
@@ -1,0 +1,5 @@
+---
+'@opencx/widget-react': patch
+---
+
+wiggle the chat input bar when send is blocked by awaiting ai reply

--- a/packages/react/src/screens/chat/ChatFooter.tsx
+++ b/packages/react/src/screens/chat/ChatFooter.tsx
@@ -351,7 +351,8 @@ function ChatInput() {
               className={cn(
                 'rounded-full size-8 flex items-center justify-center p-0',
                 shouldBlockSending &&
-                  'opacity-50 cursor-not-allowed active:scale-100 hover:active:scale-100',
+                  // translate-x-0 makes Wobble bail out, so the blocked button doesn't hover-scale or slide
+                  'opacity-50 cursor-not-allowed active:scale-100 hover:active:scale-100 translate-x-0',
               )}
             >
               <AnimatePresence mode="wait">

--- a/packages/react/src/screens/chat/ChatFooter.tsx
+++ b/packages/react/src/screens/chat/ChatFooter.tsx
@@ -10,7 +10,7 @@ import {
   useWidgetRouter,
   type FileWithProgress,
 } from '@opencx/widget-react-headless';
-import { AnimatePresence } from 'framer-motion';
+import { AnimatePresence, motion, useAnimationControls } from 'framer-motion';
 import {
   AlertCircle,
   ArrowUpIcon,
@@ -159,6 +159,14 @@ function ChatInput() {
   const shouldBlockSending =
     disableSendingWhenAwaitingAIReply !== false && isAwaitingBotReply;
 
+  const wiggleControls = useAnimationControls();
+  const wiggle = () => {
+    void wiggleControls.start({
+      x: [0, -1.2, 1.2, -0.9, 0.9, -0.6, 0.6, 0],
+      transition: { duration: 0.4, ease: 'easeInOut' },
+    });
+  };
+
   const handleFileDrop = (acceptedFiles: File[]) => {
     appendFiles(acceptedFiles);
   };
@@ -166,7 +174,10 @@ function ChatInput() {
   const cannotSend = !inputText.trim() && successFiles.length === 0;
 
   const handleSubmit = async () => {
-    if (shouldBlockSending) return;
+    if (shouldBlockSending) {
+      wiggle();
+      return;
+    }
     if (cannotSend) return;
 
     if (isUploading) {
@@ -241,10 +252,12 @@ function ChatInput() {
       {...dropzone__getRootProps()}
     >
       <input {...dropzone__getInputProps()} />
-      <div
+      <motion.div
         {...dc('chat/input_box/inner_root')}
+        initial={{ x: 0 }}
+        animate={wiggleControls}
         className={cn(
-          'transition-all',
+          'transition-colors',
           'bg-white',
           // 'border',
           'relative rounded-3xl flex flex-col gap-2 p-2',
@@ -333,8 +346,13 @@ function ChatInput() {
             <Button
               size="fit"
               onClick={handleSubmit}
-              disabled={shouldBlockSending || isUploading || cannotSend}
-              className="rounded-full size-8 flex items-center justify-center p-0"
+              disabled={isUploading || cannotSend}
+              aria-disabled={shouldBlockSending || undefined}
+              className={cn(
+                'rounded-full size-8 flex items-center justify-center p-0',
+                shouldBlockSending &&
+                  'opacity-50 cursor-not-allowed active:scale-100 hover:active:scale-100',
+              )}
             >
               <AnimatePresence mode="wait">
                 {shouldBlockSending || isUploading ? (
@@ -350,7 +368,7 @@ function ChatInput() {
             </Button>
           </Tooltippy>
         </div>
-      </div>
+      </motion.div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- when `disableSendingWhenAwaitingAIReply` is on and the AI is mid-reply, submit attempts (Enter / send button click) silently dropped — no visual feedback
- the input bar now does a subtle damped horizontal wiggle (~1.2px peak, 0.4s) on every blocked submit attempt
- the send button keeps the disabled look (dim, no active scale) while still receiving clicks so the wiggle can fire; the spinning `CircleDashed` icon is unchanged

## Notes
- swapped `transition-all` → `transition-colors` on the input bar so CSS doesn't smooth over framer-motion's keyframe transform (that was killing the wiggle visually)
- `aria-disabled={shouldBlockSending || undefined}` preserves the semantically-disabled state for screen readers without blocking pointer events
- no new deps — uses framer-motion `useAnimationControls`, already in the bundle