### PR TITLE
feat: host-page trigger API to open/prefill/answer the widget

### DIFF
--- a/packages/core/src/__tests__/context/message/inject-local-agent-message.spec.ts
+++ b/packages/core/src/__tests__/context/message/inject-local-agent-message.spec.ts
@@ -1,0 +1,170 @@
+import '../../api-caller.mock';
+
+import { ApiCaller } from '../../../api/api-caller';
+import { WidgetCtx } from '../../../context/widget.ctx';
+import type { MessageDto, SessionDto } from '../../../types/dtos';
+import type { WidgetAiMessage, WidgetMessageU } from '../../../types/messages';
+import { genUuid } from '../../../utils/uuid';
+import { TestUtils } from '../../test-utils';
+
+/* ------------------------------------------------------ */
+/*                        Helpers                         */
+/* ------------------------------------------------------ */
+
+const init = async (
+  config: Parameters<typeof WidgetCtx.initialize>[0]['config'] = { token: '' },
+) => {
+  const widgetCtx = await WidgetCtx.initialize({ config });
+  await TestUtils.sleep(20);
+  return widgetCtx;
+};
+
+const makeSessionDto = (overrides: Partial<SessionDto> = {}): SessionDto => ({
+  id: genUuid(),
+  ticketNumber: 1,
+  assignee: { kind: 'ai', name: null, avatarUrl: null },
+  channel: '',
+  createdAt: new Date().toISOString(),
+  isHandedOff: false,
+  isOpened: true,
+  isVerified: false,
+  lastMessage: '',
+  updatedAt: new Date().toISOString(),
+  modeId: null,
+  latestStateCheckpointPayload: null,
+  ...overrides,
+});
+
+const aiHistoryItem = (id = genUuid(), text = 'ai-text'): MessageDto => ({
+  type: 'message',
+  publicId: id,
+  content: { text },
+  sender: { kind: 'ai', name: null, avatar: null },
+  sentAt: new Date().toISOString(),
+  attachments: null,
+  actionCalls: null,
+  systemMessagePayload: { type: 'none' },
+});
+
+/** Sets the session so `ActiveSessionPollingCtx` starts and fires immediately. */
+const triggerPoll = async (widgetCtx: WidgetCtx, session: SessionDto) => {
+  widgetCtx.sessionCtx.sessionState.setPartial({ session });
+  await TestUtils.sleep(50);
+};
+
+const messagesOf = (widgetCtx: WidgetCtx): WidgetMessageU[] =>
+  widgetCtx.messageCtx.state.get().messages;
+
+/* ------------------------------------------------------ */
+/*                         Tests                          */
+/* ------------------------------------------------------ */
+
+suite('messageCtx.injectLocalAgentMessage', () => {
+  test('appends a correctly-shaped AI bot_message bubble', async () => {
+    const widgetCtx = await init();
+    widgetCtx.messageCtx.injectLocalAgentMessage(
+      'Onboarding takes ~2 minutes.',
+    );
+
+    const messages = messagesOf(widgetCtx);
+    expect(messages).toHaveLength(1);
+    const msg = messages[0] as WidgetAiMessage;
+    expect(msg.type).toBe('AI');
+    expect(msg.component).toBe('bot_message');
+    expect(msg.data.message).toBe('Onboarding takes ~2 minutes.');
+    expect(typeof msg.id).toBe('string');
+    expect(msg.id.length).toBeGreaterThan(0);
+    expect(typeof msg.timestamp).toBe('string');
+  });
+
+  test('uses config.bot for the agent identity when provided', async () => {
+    const widgetCtx = await init({
+      token: '',
+      bot: { name: 'Volt', avatarUrl: null },
+    });
+    widgetCtx.messageCtx.injectLocalAgentMessage('hi');
+    const msg = messagesOf(widgetCtx)[0] as WidgetAiMessage;
+    expect(msg.agent?.name).toBe('Volt');
+    expect(msg.agent?.isAi).toBe(true);
+  });
+
+  test('trims the message text', async () => {
+    const widgetCtx = await init();
+    widgetCtx.messageCtx.injectLocalAgentMessage('  hello  ');
+    expect((messagesOf(widgetCtx)[0] as WidgetAiMessage).data.message).toBe(
+      'hello',
+    );
+  });
+
+  test('no-ops on empty or whitespace-only input', async () => {
+    const widgetCtx = await init();
+    widgetCtx.messageCtx.injectLocalAgentMessage('');
+    widgetCtx.messageCtx.injectLocalAgentMessage('   ');
+    expect(messagesOf(widgetCtx)).toHaveLength(0);
+  });
+
+  test('does NOT call the API (purely client-side)', async () => {
+    const widgetCtx = await init();
+    widgetCtx.messageCtx.injectLocalAgentMessage('canned');
+    expect(ApiCaller.prototype.sendMessage).not.toHaveBeenCalled();
+  });
+
+  test('appends after existing messages and preserves order across injects', async () => {
+    const widgetCtx = await init();
+    widgetCtx.messageCtx.state.setPartial({
+      messages: [
+        {
+          id: 'u1',
+          type: 'USER',
+          content: 'q',
+          deliveredAt: null,
+          timestamp: null,
+        },
+      ],
+    });
+    widgetCtx.messageCtx.injectLocalAgentMessage('first');
+    widgetCtx.messageCtx.injectLocalAgentMessage('second');
+
+    const msgs = messagesOf(widgetCtx);
+    expect(msgs.map((m) => m.type)).toEqual(['USER', 'AI', 'AI']);
+    expect((msgs[1] as WidgetAiMessage).data.message).toBe('first');
+    expect((msgs[2] as WidgetAiMessage).data.message).toBe('second');
+  });
+
+  test('assigns a unique id to each injected bubble', async () => {
+    const widgetCtx = await init();
+    widgetCtx.messageCtx.injectLocalAgentMessage('a');
+    widgetCtx.messageCtx.injectLocalAgentMessage('b');
+    const [m1, m2] = messagesOf(widgetCtx);
+    expect(m1!.id).not.toBe(m2!.id);
+  });
+
+  test('survives a polling cycle (poller merges by id, never replaces)', async () => {
+    const widgetCtx = await init();
+    const sessionId = genUuid();
+    const polledAiId = genUuid();
+    TestUtils.mock.ApiCaller.pollSessionAndHistory(ApiCaller, {
+      data: {
+        session: makeSessionDto({ id: sessionId }),
+        history: [aiHistoryItem(polledAiId, 'from server')],
+      },
+    });
+
+    widgetCtx.messageCtx.injectLocalAgentMessage('canned answer');
+    const injectedId = messagesOf(widgetCtx)[0]!.id;
+
+    await triggerPoll(widgetCtx, makeSessionDto({ id: sessionId }));
+
+    const ids = messagesOf(widgetCtx).map((m) => m.id);
+    expect(ids).toContain(injectedId); // injected bubble survived the poll
+    expect(ids).toContain(polledAiId); // server message was appended alongside
+  });
+
+  test('is cleared by widgetCtx.resetChat()', async () => {
+    const widgetCtx = await init();
+    widgetCtx.messageCtx.injectLocalAgentMessage('canned');
+    expect(messagesOf(widgetCtx)).toHaveLength(1);
+    widgetCtx.resetChat();
+    expect(messagesOf(widgetCtx)).toHaveLength(0);
+  });
+});

--- a/packages/core/src/__tests__/context/widget/composer-draft.spec.ts
+++ b/packages/core/src/__tests__/context/widget/composer-draft.spec.ts
@@ -1,0 +1,57 @@
+import '../../api-caller.mock';
+
+import { WidgetCtx } from '../../../context/widget.ctx';
+import { TestUtils } from '../../test-utils';
+
+const init = async () => {
+  const widgetCtx = await WidgetCtx.initialize({ config: { token: '' } });
+  await TestUtils.sleep(20);
+  return widgetCtx;
+};
+
+suite('composer draft', () => {
+  test('defaults to an empty string', async () => {
+    const widgetCtx = await init();
+    expect(widgetCtx.composerDraft.get()).toBe('');
+  });
+
+  test('setComposerDraft sets the draft text', async () => {
+    const widgetCtx = await init();
+    widgetCtx.setComposerDraft('How do I withdraw earnings?');
+    expect(widgetCtx.composerDraft.get()).toBe('How do I withdraw earnings?');
+  });
+
+  test('setComposerDraft can be overwritten and cleared', async () => {
+    const widgetCtx = await init();
+    widgetCtx.setComposerDraft('first');
+    widgetCtx.setComposerDraft('second');
+    expect(widgetCtx.composerDraft.get()).toBe('second');
+    widgetCtx.setComposerDraft('');
+    expect(widgetCtx.composerDraft.get()).toBe('');
+  });
+
+  test('resetChat() clears the draft (preserves "draft clears on new chat")', async () => {
+    const widgetCtx = await init();
+    widgetCtx.setComposerDraft('a pending question');
+    widgetCtx.resetChat();
+    expect(widgetCtx.composerDraft.get()).toBe('');
+  });
+
+  test('notifies subscribers when the draft changes', async () => {
+    const widgetCtx = await init();
+    const seen: string[] = [];
+    widgetCtx.composerDraft.subscribe((v) => seen.push(v));
+    widgetCtx.setComposerDraft('x');
+    widgetCtx.setComposerDraft('xy');
+    expect(seen).toEqual(['x', 'xy']);
+  });
+
+  test('does not notify when the draft is set to the same value', async () => {
+    const widgetCtx = await init();
+    widgetCtx.setComposerDraft('same');
+    const seen: string[] = [];
+    widgetCtx.composerDraft.subscribe((v) => seen.push(v));
+    widgetCtx.setComposerDraft('same');
+    expect(seen).toEqual([]);
+  });
+});

--- a/packages/core/src/context/message.ctx.ts
+++ b/packages/core/src/context/message.ctx.ts
@@ -66,13 +66,47 @@ export class MessageCtx {
   };
 
   /**
+   * Appends a client-only AI ("agent") bubble to the transcript WITHOUT contacting
+   * the server. Used by the host-facing `presentAnswer` trigger to show a canned
+   * answer. The bubble carries a client-generated id, so the active-session poller
+   * (which only appends server messages and dedupes by id) never removes or
+   * duplicates it. It is ephemeral: not persisted, not part of the AI's context,
+   * and cleared by `reset()` / `resetChat()`. No-ops on empty input.
+   */
+  injectLocalAgentMessage = (message: string): void => {
+    const trimmed = message.trim();
+    if (!trimmed) return;
+    const aiMessage: WidgetAiMessage = {
+      id: genUuid(),
+      type: 'AI',
+      timestamp: new Date().toISOString(),
+      component: 'bot_message',
+      agent: this.config.bot
+        ? {
+            name: this.config.bot.name || '',
+            isAi: true,
+            // Let avatar be resolved from config at render time (mirror toBotMessage)
+            avatarUrl: null,
+            avatar: null,
+            id: null,
+          }
+        : undefined,
+      data: { message: trimmed },
+    };
+    this.state.setPartial({
+      messages: [...this.state.get().messages, aiMessage],
+    });
+  };
+
+  /**
    * Fires `config.hooks.onMessageReceived` for AI or human-agent messages exactly
    * once per id. Safe to call from any path that ingests messages from the server
    * (send-message response, polling, initial history fetch).
    */
   dispatchToOnMessageReceivedHook = (message: WidgetMessageU): void => {
     if (message.type === 'USER') return;
-    if (this.messageIdsDispatchedToOnMessageReceivedHook.has(message.id)) return;
+    if (this.messageIdsDispatchedToOnMessageReceivedHook.has(message.id))
+      return;
     const session = this.sessionCtx.sessionState.get().session;
     if (!session) return;
     this.messageIdsDispatchedToOnMessageReceivedHook.add(message.id);
@@ -166,7 +200,9 @@ export class MessageCtx {
                   data: {
                     message: m.message,
                   },
-                  agent: this.config.bot ? { ...this.config.bot, isAi: true, id: null } : undefined,
+                  agent: this.config.bot
+                    ? { ...this.config.bot, isAi: true, id: null }
+                    : undefined,
                 }) satisfies WidgetAiMessage,
             )
         : [];
@@ -260,7 +296,8 @@ export class MessageCtx {
         }
       } else {
         const errorMessage = this.toBotErrorMessage(
-          data?.error?.message || 'Something went wrong. Please refresh the page or try again.',
+          data?.error?.message ||
+            'Something went wrong. Please refresh the page or try again.',
         );
         const currentMessages = this.state.get().messages;
         this.state.setPartial({

--- a/packages/core/src/context/widget.ctx.ts
+++ b/packages/core/src/context/widget.ctx.ts
@@ -9,6 +9,7 @@ import { MessageCtx } from './message.ctx';
 import { RouterCtx } from './router.ctx';
 import { SessionCtx } from './session.ctx';
 import { StorageCtx } from './storage.ctx';
+import { PrimitiveState } from '../utils/PrimitiveState';
 
 export class WidgetCtx {
   public config: WidgetConfig;
@@ -21,6 +22,14 @@ export class WidgetCtx {
   public routerCtx: RouterCtx;
   public storageCtx?: StorageCtx;
   public modes: ModeDto[] = [];
+
+  /**
+   * The chat composer's draft text. Lifted out of the input component so it can
+   * be set programmatically (host-facing `prefill` trigger) and read/written by
+   * `ChatInput`. Cleared on `resetChat()` to preserve the prior "draft clears on
+   * new chat" behaviour.
+   */
+  public composerDraft = new PrimitiveState<string>('');
 
   public org: {
     id: string;
@@ -133,8 +142,13 @@ export class WidgetCtx {
     });
   };
 
+  setComposerDraft = (text: string) => {
+    this.composerDraft.set(text);
+  };
+
   resetChat = () => {
     this.sessionCtx.reset();
     this.messageCtx.reset();
+    this.composerDraft.reset();
   };
 }

--- a/packages/embed/src/__tests__/triggers.spec.ts
+++ b/packages/embed/src/__tests__/triggers.spec.ts
@@ -1,0 +1,82 @@
+import { resolveTriggerAction } from '../triggers';
+
+const el = (html: string): Element => {
+  const container = document.createElement('div');
+  container.innerHTML = html;
+  return container.firstElementChild!;
+};
+
+suite('resolveTriggerAction', () => {
+  test('data-opencx-open → open', () => {
+    expect(resolveTriggerAction(el('<a data-opencx-open>Chat</a>'))).toEqual({
+      kind: 'open',
+    });
+  });
+
+  test('data-opencx-prefill → prefill with its value', () => {
+    expect(
+      resolveTriggerAction(
+        el('<a data-opencx-prefill="How do I withdraw?">x</a>'),
+      ),
+    ).toEqual({ kind: 'prefill', value: 'How do I withdraw?' });
+  });
+
+  test('data-opencx-ask → ask with its value', () => {
+    expect(
+      resolveTriggerAction(
+        el('<a data-opencx-ask="What are your fees?">x</a>'),
+      ),
+    ).toEqual({ kind: 'ask', value: 'What are your fees?' });
+  });
+
+  test('data-opencx-answer → answer with its value', () => {
+    expect(
+      resolveTriggerAction(
+        el('<a data-opencx-answer="Onboarding ~2 min">x</a>'),
+      ),
+    ).toEqual({ kind: 'answer', value: 'Onboarding ~2 min' });
+  });
+
+  test('an empty attribute value is preserved (not treated as missing)', () => {
+    expect(resolveTriggerAction(el('<a data-opencx-prefill="">x</a>'))).toEqual(
+      {
+        kind: 'prefill',
+        value: '',
+      },
+    );
+  });
+
+  test('resolves from the nearest trigger ancestor when a child is clicked', () => {
+    const trigger = el('<a data-opencx-prefill="Q"><span>label</span></a>');
+    const child = trigger.querySelector('span');
+    expect(resolveTriggerAction(child)).toEqual({
+      kind: 'prefill',
+      value: 'Q',
+    });
+  });
+
+  test('precedence: prefill wins over open on the same element', () => {
+    expect(
+      resolveTriggerAction(
+        el('<a data-opencx-open data-opencx-prefill="Q">x</a>'),
+      ),
+    ).toEqual({ kind: 'prefill', value: 'Q' });
+  });
+
+  test('precedence: ask wins over answer', () => {
+    expect(
+      resolveTriggerAction(
+        el('<a data-opencx-ask="A" data-opencx-answer="B">x</a>'),
+      ),
+    ).toEqual({ kind: 'ask', value: 'A' });
+  });
+
+  test('a non-trigger element → null', () => {
+    expect(resolveTriggerAction(el('<a href="#">plain</a>'))).toBeNull();
+  });
+
+  test('a non-Element target → null', () => {
+    expect(resolveTriggerAction(null)).toBeNull();
+    expect(resolveTriggerAction(document.createTextNode('hi'))).toBeNull();
+  });
+});

--- a/packages/embed/src/__tests__/triggers.spec.ts
+++ b/packages/embed/src/__tests__/triggers.spec.ts
@@ -7,47 +7,63 @@ const el = (html: string): Element => {
 };
 
 suite('resolveTriggerAction', () => {
-  test('data-opencx-open → open', () => {
-    expect(resolveTriggerAction(el('<a data-opencx-open>Chat</a>'))).toEqual({
+  test('opencx-open → open', () => {
+    expect(resolveTriggerAction(el('<a opencx-open>Chat</a>'))).toEqual({
       kind: 'open',
     });
   });
 
-  test('data-opencx-prefill → prefill with its value', () => {
+  test('opencx-prefill → prefill with its value', () => {
     expect(
-      resolveTriggerAction(
-        el('<a data-opencx-prefill="How do I withdraw?">x</a>'),
-      ),
+      resolveTriggerAction(el('<a opencx-prefill="How do I withdraw?">x</a>')),
     ).toEqual({ kind: 'prefill', value: 'How do I withdraw?' });
   });
 
-  test('data-opencx-ask → ask with its value', () => {
+  test('opencx-ask → ask with its value', () => {
     expect(
-      resolveTriggerAction(
-        el('<a data-opencx-ask="What are your fees?">x</a>'),
-      ),
+      resolveTriggerAction(el('<a opencx-ask="What are your fees?">x</a>')),
     ).toEqual({ kind: 'ask', value: 'What are your fees?' });
   });
 
-  test('data-opencx-answer → answer with its value', () => {
+  test('opencx-answer → answer with its value', () => {
     expect(
-      resolveTriggerAction(
-        el('<a data-opencx-answer="Onboarding ~2 min">x</a>'),
-      ),
+      resolveTriggerAction(el('<a opencx-answer="Onboarding ~2 min">x</a>')),
     ).toEqual({ kind: 'answer', value: 'Onboarding ~2 min' });
   });
 
+  test('the data-opencx-* form is still accepted for every action', () => {
+    expect(resolveTriggerAction(el('<a data-opencx-open>Chat</a>'))).toEqual({
+      kind: 'open',
+    });
+    expect(
+      resolveTriggerAction(el('<a data-opencx-prefill="Q">x</a>')),
+    ).toEqual({ kind: 'prefill', value: 'Q' });
+    expect(resolveTriggerAction(el('<a data-opencx-ask="Q">x</a>'))).toEqual({
+      kind: 'ask',
+      value: 'Q',
+    });
+    expect(
+      resolveTriggerAction(el('<a data-opencx-answer="A">x</a>')),
+    ).toEqual({ kind: 'answer', value: 'A' });
+  });
+
+  test('the bare form wins over the data- form on the same element', () => {
+    expect(
+      resolveTriggerAction(
+        el('<a opencx-prefill="bare" data-opencx-prefill="data">x</a>'),
+      ),
+    ).toEqual({ kind: 'prefill', value: 'bare' });
+  });
+
   test('an empty attribute value is preserved (not treated as missing)', () => {
-    expect(resolveTriggerAction(el('<a data-opencx-prefill="">x</a>'))).toEqual(
-      {
-        kind: 'prefill',
-        value: '',
-      },
-    );
+    expect(resolveTriggerAction(el('<a opencx-prefill="">x</a>'))).toEqual({
+      kind: 'prefill',
+      value: '',
+    });
   });
 
   test('resolves from the nearest trigger ancestor when a child is clicked', () => {
-    const trigger = el('<a data-opencx-prefill="Q"><span>label</span></a>');
+    const trigger = el('<a opencx-prefill="Q"><span>label</span></a>');
     const child = trigger.querySelector('span');
     expect(resolveTriggerAction(child)).toEqual({
       kind: 'prefill',
@@ -57,17 +73,19 @@ suite('resolveTriggerAction', () => {
 
   test('precedence: prefill wins over open on the same element', () => {
     expect(
-      resolveTriggerAction(
-        el('<a data-opencx-open data-opencx-prefill="Q">x</a>'),
-      ),
+      resolveTriggerAction(el('<a opencx-open opencx-prefill="Q">x</a>')),
+    ).toEqual({ kind: 'prefill', value: 'Q' });
+  });
+
+  test('precedence: prefill wins over open across forms (data-open + bare prefill)', () => {
+    expect(
+      resolveTriggerAction(el('<a data-opencx-open opencx-prefill="Q">x</a>')),
     ).toEqual({ kind: 'prefill', value: 'Q' });
   });
 
   test('precedence: ask wins over answer', () => {
     expect(
-      resolveTriggerAction(
-        el('<a data-opencx-ask="A" data-opencx-answer="B">x</a>'),
-      ),
+      resolveTriggerAction(el('<a opencx-ask="A" opencx-answer="B">x</a>')),
     ).toEqual({ kind: 'ask', value: 'A' });
   });
 

--- a/packages/embed/src/index.tsx
+++ b/packages/embed/src/index.tsx
@@ -1,24 +1,106 @@
 import type { WidgetConfig } from '@opencx/widget-core';
-import { Widget } from '@opencx/widget-react';
+import { Widget, type WidgetRef } from '@opencx/widget-react';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { version } from '../package.json';
+import { resolveTriggerAction } from './triggers';
 
 const defaultRootId = 'opencx-root';
+
+/**
+ * Host-page controller for driving the widget from your own links/buttons.
+ * Every method opens the widget as needed and is a no-op (with a warning) until
+ * the widget has finished mounting.
+ */
+type OpenCXWidgetController = {
+  /** Open the widget (no-op if already open — no remount). */
+  open: () => void;
+  /** Close the widget. */
+  close: () => void;
+  /** Toggle the widget open/closed. */
+  toggle: () => void;
+  /** Open the widget and pre-fill the composer with `message` WITHOUT sending. */
+  prefill: (message: string) => void;
+  /** Open the widget on a fresh chat and send `message` immediately. */
+  ask: (message: string) => void;
+  /** Open the widget on a fresh chat and show `message` as a canned AI bubble. */
+  presentAnswer: (message: string) => void;
+};
 
 declare global {
   interface Window {
     initOpenScript: typeof initOpenScript;
     openCXWidgetVersion: string;
+    opencxWidget: OpenCXWidgetController;
+  }
+}
+
+const widgetRef = React.createRef<WidgetRef>();
+
+function withWidget<A extends unknown[]>(
+  fn: (ref: WidgetRef, ...args: A) => void,
+): (...args: A) => void {
+  return (...args: A) => {
+    const ref = widgetRef.current;
+    if (!ref) {
+      console.warn(
+        'opencxWidget: the widget is not ready yet — call this after initOpenScript() has mounted.',
+      );
+      return;
+    }
+    fn(ref, ...args);
+  };
+}
+
+const controller: OpenCXWidgetController = {
+  open: withWidget((ref) => ref.open()),
+  close: withWidget((ref) => ref.close()),
+  toggle: withWidget((ref) => ref.toggle()),
+  prefill: withWidget((ref, message: string) => ref.prefill(message)),
+  ask: withWidget((ref, message: string) => void ref.ask(message)),
+  presentAnswer: withWidget((ref, message: string) =>
+    ref.presentAnswer(message),
+  ),
+};
+
+/**
+ * Zero-JS triggers: any element carrying one of these data attributes drives the
+ * widget on click.
+ *   <a data-opencx-open>Chat</a>
+ *   <a data-opencx-prefill="How do I...?">Ask</a>
+ *   <a data-opencx-ask="What are your fees?">Fees</a>
+ *   <a data-opencx-answer="Onboarding takes ~2 minutes...">Onboarding</a>
+ */
+function handleTriggerClick(event: MouseEvent) {
+  const action = resolveTriggerAction(event.target);
+  if (!action) return;
+
+  event.preventDefault();
+
+  switch (action.kind) {
+    case 'prefill':
+      controller.prefill(action.value);
+      break;
+    case 'ask':
+      controller.ask(action.value);
+      break;
+    case 'answer':
+      controller.presentAnswer(action.value);
+      break;
+    case 'open':
+      controller.open();
+      break;
   }
 }
 
 function initOpenScript(options: WidgetConfig) {
-  render(defaultRootId, <Widget options={options} />);
+  render(defaultRootId, <Widget ref={widgetRef} options={options} />);
 }
 
 window.initOpenScript = initOpenScript;
 window.openCXWidgetVersion = version;
+window.opencxWidget = controller;
+document.addEventListener('click', handleTriggerClick);
 
 export function render(rootId: string, component: React.JSX.Element) {
   let rootElement = document.getElementById(rootId);

--- a/packages/embed/src/index.tsx
+++ b/packages/embed/src/index.tsx
@@ -64,12 +64,13 @@ const controller: OpenCXWidgetController = {
 };
 
 /**
- * Zero-JS triggers: any element carrying one of these data attributes drives the
+ * Zero-JS triggers: any element carrying one of these attributes drives the
  * widget on click.
- *   <a data-opencx-open>Chat</a>
- *   <a data-opencx-prefill="How do I...?">Ask</a>
- *   <a data-opencx-ask="What are your fees?">Fees</a>
- *   <a data-opencx-answer="Onboarding takes ~2 minutes...">Onboarding</a>
+ *   <a opencx-open>Chat</a>
+ *   <a opencx-prefill="How do I...?">Ask</a>
+ *   <a opencx-ask="What are your fees?">Fees</a>
+ *   <a opencx-answer="Onboarding takes ~2 minutes...">Onboarding</a>
+ * The `data-opencx-*` form is also accepted.
  */
 function handleTriggerClick(event: MouseEvent) {
   const action = resolveTriggerAction(event.target);

--- a/packages/embed/src/triggers.ts
+++ b/packages/embed/src/triggers.ts
@@ -5,11 +5,19 @@ export type TriggerAction =
   | { kind: 'answer'; value: string };
 
 export const TRIGGER_SELECTOR =
+  '[opencx-open],[opencx-prefill],[opencx-ask],[opencx-answer],' +
   '[data-opencx-open],[data-opencx-prefill],[data-opencx-ask],[data-opencx-answer]';
+
+/** Reads `opencx-*`, falling back to the `data-opencx-*` form. */
+function triggerAttribute(el: Element, name: string): string | null {
+  return el.getAttribute(`opencx-${name}`) ?? el.getAttribute(`data-opencx-${name}`);
+}
 
 /**
  * Resolves the OpenCX trigger action for a clicked element (or its nearest
  * trigger ancestor). Returns `null` when the target is not a trigger.
+ * The documented attributes are `opencx-*`; the `data-opencx-*` form is also
+ * accepted for hosts that need HTML-validator-clean markup.
  * Precedence when several attributes are present: prefill > ask > answer > open.
  */
 export function resolveTriggerAction(
@@ -19,13 +27,13 @@ export function resolveTriggerAction(
   const el = target.closest(TRIGGER_SELECTOR);
   if (!el) return null;
 
-  const prefill = el.getAttribute('data-opencx-prefill');
+  const prefill = triggerAttribute(el, 'prefill');
   if (prefill !== null) return { kind: 'prefill', value: prefill };
 
-  const ask = el.getAttribute('data-opencx-ask');
+  const ask = triggerAttribute(el, 'ask');
   if (ask !== null) return { kind: 'ask', value: ask };
 
-  const answer = el.getAttribute('data-opencx-answer');
+  const answer = triggerAttribute(el, 'answer');
   if (answer !== null) return { kind: 'answer', value: answer };
 
   return { kind: 'open' };

--- a/packages/embed/src/triggers.ts
+++ b/packages/embed/src/triggers.ts
@@ -1,0 +1,32 @@
+export type TriggerAction =
+  | { kind: 'open' }
+  | { kind: 'prefill'; value: string }
+  | { kind: 'ask'; value: string }
+  | { kind: 'answer'; value: string };
+
+export const TRIGGER_SELECTOR =
+  '[data-opencx-open],[data-opencx-prefill],[data-opencx-ask],[data-opencx-answer]';
+
+/**
+ * Resolves the OpenCX trigger action for a clicked element (or its nearest
+ * trigger ancestor). Returns `null` when the target is not a trigger.
+ * Precedence when several attributes are present: prefill > ask > answer > open.
+ */
+export function resolveTriggerAction(
+  target: EventTarget | null,
+): TriggerAction | null {
+  if (!(target instanceof Element)) return null;
+  const el = target.closest(TRIGGER_SELECTOR);
+  if (!el) return null;
+
+  const prefill = el.getAttribute('data-opencx-prefill');
+  if (prefill !== null) return { kind: 'prefill', value: prefill };
+
+  const ask = el.getAttribute('data-opencx-ask');
+  if (ask !== null) return { kind: 'ask', value: ask };
+
+  const answer = el.getAttribute('data-opencx-answer');
+  if (answer !== null) return { kind: 'answer', value: answer };
+
+  return { kind: 'open' };
+}

--- a/packages/react-headless/src/hooks/useComposerDraft.ts
+++ b/packages/react-headless/src/hooks/useComposerDraft.ts
@@ -1,0 +1,14 @@
+import { usePrimitiveState } from './usePrimitiveState';
+import { useWidget } from '../WidgetProvider';
+
+/**
+ * The chat composer's draft text, lifted into core state so it can be set
+ * programmatically (e.g. the host-facing `prefill` trigger) as well as by the
+ * input component. `setDraft` updates it without sending.
+ */
+export function useComposerDraft() {
+  const { widgetCtx } = useWidget();
+  const draft = usePrimitiveState(widgetCtx.composerDraft);
+
+  return { draft, setDraft: widgetCtx.setComposerDraft };
+}

--- a/packages/react-headless/src/hooks/useMessages.ts
+++ b/packages/react-headless/src/hooks/useMessages.ts
@@ -5,5 +5,9 @@ export function useMessages() {
   const { widgetCtx } = useWidget();
   const messagesState = usePrimitiveState(widgetCtx.messageCtx.state);
 
-  return { messagesState, sendMessage: widgetCtx.messageCtx.sendMessage };
+  return {
+    messagesState,
+    sendMessage: widgetCtx.messageCtx.sendMessage,
+    injectLocalAgentMessage: widgetCtx.messageCtx.injectLocalAgentMessage,
+  };
 }

--- a/packages/react-headless/src/index.ts
+++ b/packages/react-headless/src/index.ts
@@ -10,6 +10,7 @@ export { useContact } from './hooks/useContact';
 export { useDocumentDir } from './hooks/useDocumentDir';
 export { useIsAwaitingBotReply } from './hooks/useIsAwaitingBotReply';
 export { useMessages } from './hooks/useMessages';
+export { useComposerDraft } from './hooks/useComposerDraft';
 export { usePrimitiveState } from './hooks/usePrimitiveState';
 export { useSessions } from './hooks/useSessions';
 export { useWidgetRouter } from './hooks/useWidgetRouter';

--- a/packages/react/src/WidgetImperativeHandler.tsx
+++ b/packages/react/src/WidgetImperativeHandler.tsx
@@ -8,6 +8,30 @@ import {
 } from '@opencx/widget-react-headless';
 
 export type WidgetRef = {
+  /** Open the widget. No-op if already open (no remount). */
+  open: () => void;
+  /** Close the widget. */
+  close: () => void;
+  /** Toggle the widget between open and closed. */
+  toggle: () => void;
+  /**
+   * Open the widget, go to the chat screen, and pre-fill the composer with
+   * `message` WITHOUT sending it — the visitor presses Enter to send. An
+   * already-open conversation is left intact (only the draft is set).
+   */
+  prefill: (message: string) => void;
+  /**
+   * Open the widget on a fresh chat and send `message` immediately. Alias of
+   * `newChat({ message })`.
+   */
+  ask: (message: string) => Promise<void>;
+  /**
+   * Open the widget on a fresh chat and show `message` as a canned AI bubble.
+   * The bubble is client-only: not persisted and not part of the AI's context.
+   * The visitor can keep chatting normally afterwards.
+   */
+  presentAnswer: (message: string) => void;
+  /** Open the widget on a fresh chat, optionally sending an initial `message`. */
   newChat: (options?: { message?: string }) => Promise<void>;
 };
 
@@ -23,36 +47,53 @@ export function WidgetImperativeHandler({
     toChatScreen,
     routerState: { screen },
   } = useWidgetRouter();
-  const { sendMessage } = useMessages();
+  const { sendMessage, injectLocalAgentMessage } = useMessages();
 
-  React.useImperativeHandle(
-    widgetRef,
-    () => ({
-      newChat: async (options) => {
-        if (!contactState.contact?.token) {
-          console.warn('Cannot start a new chat: contact not yet initialized.');
-          return;
-        }
+  React.useImperativeHandle(widgetRef, () => {
+    const newChat: WidgetRef['newChat'] = async (options) => {
+      if (!contactState.contact?.token) {
+        console.warn('Cannot start a new chat: contact not yet initialized.');
+        return;
+      }
 
-        console.log({ isOpen });
+      if (!isOpen) setIsOpen(true);
+
+      if (screen === 'chat') widgetCtx.resetChat();
+
+      toChatScreen();
+      if (options?.message) sendMessage({ content: options.message });
+    };
+
+    return {
+      open: () => setIsOpen(true),
+      close: () => setIsOpen(false),
+      toggle: () => setIsOpen((prev) => !prev),
+      prefill: (message) => {
         if (!isOpen) setIsOpen(true);
-
-        if (screen === 'chat') widgetCtx.resetChat();
-
-        toChatScreen();
-        if (options?.message) sendMessage({ content: options.message });
+        // Navigating to chat resets the conversation (and clears the draft),
+        // so only navigate when not already chatting, and set the draft AFTER.
+        if (screen !== 'chat') toChatScreen();
+        widgetCtx.setComposerDraft(message);
       },
-    }),
-    [
-      widgetCtx,
-      contactState,
-      setIsOpen,
-      isOpen,
-      screen,
-      toChatScreen,
-      sendMessage,
-    ],
-  );
+      ask: (message) => newChat({ message }),
+      presentAnswer: (message) => {
+        if (!isOpen) setIsOpen(true);
+        // Start a fresh chat (toChatScreen resets), then inject the canned bubble.
+        toChatScreen();
+        injectLocalAgentMessage(message);
+      },
+      newChat,
+    };
+  }, [
+    widgetCtx,
+    contactState,
+    setIsOpen,
+    isOpen,
+    screen,
+    toChatScreen,
+    sendMessage,
+    injectLocalAgentMessage,
+  ]);
 
   return null;
 }

--- a/packages/react/src/screens/chat/ChatFooter.tsx
+++ b/packages/react/src/screens/chat/ChatFooter.tsx
@@ -1,5 +1,6 @@
 import { type SendMessageDto } from '@opencx/widget-core';
 import {
+  useComposerDraft,
   useConfig,
   useCsat,
   useIsAwaitingBotReply,
@@ -142,7 +143,16 @@ function ChatInput() {
   const { sessionState } = useSessions();
   const { disableSendingWhenAwaitingAIReply } = useConfig();
   const { t } = useTranslation();
-  const [inputText, setInputText] = useState('');
+  // Composer draft lives in core state so it can be set programmatically (the
+  // host-facing `prefill` trigger) as well as by typing here.
+  const { draft: inputText, setDraft: setInputText } = useComposerDraft();
+
+  // When the composer mounts already holding draft text (e.g. set by `prefill`
+  // before navigating to chat), focus it so the visitor can just press Enter.
+  useEffect(() => {
+    if (inputText.trim()) inputRef.current?.focus();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const {
     allFiles,


### PR DESCRIPTION
## What

A host-page API so a link/button on the customer's own site can drive the embedded widget — not just the floating bubble.

**`window.opencxWidget`**
- `open()` / `close()` / `toggle()` — smooth, no remount
- `prefill(text)` — open + go to chat + fill the composer **without sending** (visitor presses Enter)
- `ask(text)` — open a fresh chat and send immediately
- `presentAnswer(text)` — open a fresh chat and show a canned AI bubble (client-only)

**Zero-JS data attributes**
```html
<a opencx-open>Chat</a>
<a opencx-prefill="How do I withdraw?">Ask</a>
<a opencx-ask="What are your fees?">Fees</a>
<a opencx-answer="Onboarding takes ~2 min...">Onboarding</a>
```

## Why

The embed (`initOpenScript`) rendered `<Widget>` with no ref, so the existing `WidgetRef.newChat` was unreachable from a script-tag host. There was also no way to prefill the composer without sending, or to show a canned answer.

## How

- **embed**: wire a ref to `<Widget>`, expose `window.opencxWidget`, delegate `opencx-*` clicks (the `data-opencx-*` form is also accepted) (resolution extracted to `triggers.ts`).
- **react**: extend `WidgetRef`/`WidgetImperativeHandler`; focus the composer when it mounts holding a draft.
- **core**: lift the composer draft into `WidgetCtx` (`setComposerDraft`, cleared on `resetChat`) so prefill sets it without sending; add `MessageCtx.injectLocalAgentMessage` — client-only, survives polling via id dedupe, makes no API call.
- **react-headless**: `useComposerDraft` hook; expose `injectLocalAgentMessage`.

## Notes

- `presentAnswer` is intentionally ephemeral — not persisted, not part of the AI's context. The visitor can keep chatting normally after.
- Additive only: no existing consumer passes a `Widget` ref, so extending `WidgetRef` is safe.

## Tests

`pnpm test` green. New: composer-draft lifecycle, `injectLocalAgentMessage` shape/order/dedupe/poll-survival/reset/no-send, and `opencx-*` / `data-opencx-*` resolution.
