### PR TITLE
feat: declarative Chat CTA card near the launcher

### DIFF
--- a/.changeset/chat-cta-card.md
+++ b/.changeset/chat-cta-card.md
@@ -1,0 +1,13 @@
+---
+'@opencx/widget-core': minor
+'@opencx/widget-react': minor
+'@opencx/widget': minor
+---
+
+Add a declarative Chat CTA card: `WidgetConfig.cta` renders a proactive
+teaser near the launcher with a title, body, image, avatars, action buttons
+(open-chat / ask / prefill / url), and an optional inline composer. Includes
+dismiss persistence (`dismissForDays`), `showAfterSeconds` / `urlMatch` rules,
+`onCtaDisplayed` / `onCtaClicked` / `onCtaDismissed` hooks, `cta/*`
+cssOverrides component names, and `showCta()` / `hideCta()` on `WidgetRef`
+and `window.opencxWidget`.

--- a/.changeset/chat-cta-card.md
+++ b/.changeset/chat-cta-card.md
@@ -1,5 +1,6 @@
 ---
 '@opencx/widget-core': minor
+'@opencx/widget-react-headless': minor
 '@opencx/widget-react': minor
 '@opencx/widget': minor
 ---

--- a/docs/cta-design-notebook.md
+++ b/docs/cta-design-notebook.md
@@ -97,6 +97,20 @@ Everything except `title` is opt-in. Restyle any slot via
 
 ---
 
+## Traps found the hard way
+
+- **Full-bleed images inside a padded Tailwind card need BOTH fixes:**
+  `w-[calc(100%_+_2rem)]` — the underscores are mandatory (Tailwind turns them
+  into spaces; `calc(100%+2rem)` without spaces is invalid CSS and the browser
+  silently drops it) — **and** `max-w-none`, because preflight ships
+  `img { max-width: 100% }` which clamps the calc right back. Either one
+  missing = image shifted left with a mystery gap under the dismiss button.
+  Symptom is asymmetric (margin pulls left, width stays short), so it reads
+  as "the X button pushed my image" when nothing of the sort happened.
+- Debug method that found it: measure `getBoundingClientRect()` of image vs
+  card root inside the iframe, then diff the stylesheet rule against the
+  element's computed style — visual inspection alone mis-attributes the cause.
+
 ## cssOverrides recipes (tested)
 
 ```css

--- a/docs/cta-design-notebook.md
+++ b/docs/cta-design-notebook.md
@@ -1,0 +1,187 @@
+# CTA Card Design Notebook
+
+Working notes on designing OpenCX Chat CTA cards — what the component gives you,
+what great cards do with it, and lessons learned iterating on 10 real-brand
+examples (Stripe, Notion, Airbnb, Nike, Shopify, Spotify, Linear, Mailchimp,
+Allbirds, Netflix). Living document; updated per design round.
+
+## The anatomy (what you're composing)
+
+```
+[imageUrl]        — full-bleed header, rounds with the card
+title             — the only required field
+body              — one supporting line (restyles well: coupon chip, presence line)
+avatarUrls[]      — overlapping team row
+buttons[]         — open-chat | ask | prefill | url, primary/secondary
+composer          — inline input, submits into a fresh chat
+```
+Everything except `title` is opt-in. Restyle any slot via
+`cssOverrides` + `[data-component="cta/*"]`.
+
+---
+
+## Round 1 — critique of the first 10 (lead-designer pass)
+
+### Component-level findings (fix once, every card improves)
+
+1. **Flat vertical rhythm.** A uniform gap between every section made cards read
+   as a stack of parts, not a composed message. Title+body are one thought —
+   4-6px apart; groups (text / social proof / actions / composer) need 12-14px.
+   *Rule: spacing encodes grouping. Two spacing values minimum.*
+2. **Underweight title.** 16px/semibold reads like a list item. A teaser lives
+   or dies on its headline: 17px/bold/snug tracking.
+3. **The button wall.** Three identical full-width buttons = 130px of
+   undifferentiated chrome. Primary must dominate (weight, fill); secondaries
+   recede. Also: card 16px radius, buttons 12px, composer 999px — three radius
+   languages in one 360px card. Pick a family.
+4. **Avatars as afterthought.** 28px + timid overlap reads decorative. Crisp's
+   works because avatars are ≥32px, tightly overlapped, adjacent to the
+   presence line ("team is online") so they *prove* the claim.
+5. **Dismiss X has no home on imagery.** Fine on white; invisible on photo
+   headers (Netflix tiles). Over an image it needs a scrim (black/25 circle +
+   white glyph). Also grew the hit area.
+6. **Wireframe composer.** Border-only input on white looks like a mockup.
+   Filled input (secondary token), border appears only on focus — now it reads
+   as a real, inviting control.
+7. **Generic elevation.** Tailwind `shadow-xl` = tight dropdown shadow. A
+   floating teaser wants soft, wide, low-opacity ambient shadow
+   (`0 12px 40px -8px rgba(0,0,0,.18)`) + hairline `black/5` border so it
+   holds an edge on both white and busy pages.
+8. **Emoji tax.** 10/10 titles ended with an emoji → instant template smell.
+   Emoji is seasoning: use when it carries voice (Spotify's "cancel… 👀"),
+   drop otherwise.
+
+### Per-brand findings
+
+- **Stripe** — strongest baseline. Copy trimmed: body shouldn't repeat what the
+  primary button says.
+- **Notion** — white card fought the dark hero AND the white product screenshot
+  behind it. Verdict: on dark heroes, the card goes dark (`#191919`), primary
+  button inverts to white. Match the surface you float over.
+- **Airbnb** — avatars too small to sell "team is online"; primary button
+  should use the brand's actual gradient (`#E61E4D→#D70466`) — brands with a
+  signature gradient should keep it in the card. Presence dot added via
+  `body::before` trick (see recipes).
+- **Nike** — "minimal" read as "unfinished". Minimal needs conviction: their
+  voice is loud — uppercase condensed bold italic title, composer-only. A
+  one-liner + input IS a strong variant when the type carries it.
+- **Shopify** — image→copy→actions→composer is the canonical full stack; keep.
+- **Spotify** — best dark execution; secondary fills needed one step more
+  separation from the card (#242424 → #2A2A2A on #121212).
+- **Linear** — the purple gradient card was *my* idea of Linear, not Linear's.
+  Their world is near-black + hairline borders + restrained purple accents.
+  Authenticity beats variety: derive the card from the brand's own surfaces.
+- **Mailchimp** — neo-brutalist quiz (hard offset shadow, 2px peppercorn
+  border) is the keeper of the set. Push further: cream card (#FBF6EC).
+- **Allbirds** — the coupon chip (dashed border, monospace, letterspaced code)
+  works; anchor of the card.
+- **Netflix** — raw og/hero art is too noisy at full height behind a card;
+  constrain image headers (`aspect-ratio` + `object-fit: cover`) into a banner
+  strip.
+
+### Principles distilled (v1)
+
+- **Match the surface you float over.** Light page → light card; dark hero →
+  dark card. The card is a guest on the host page.
+- **One primary action.** Everything else recedes. If every button shouts,
+  none does.
+- **The body line is a power slot.** It restyles into a coupon chip, a
+  presence line, a punchline — one field, many jobs.
+- **Brand color goes on the primary button + launcher, not the card canvas** —
+  unless the brand owns a canvas (Spotify black, Mailchimp cream).
+- **Copy: say the action, not the vibe.** "Talk to sales", "Claim my
+  discount", "Recommend me a thriller" — verb-first, specific, sentence case.
+- **Questions make the best secondaries.** An `ask` button phrased as the
+  visitor's own words ("How do refunds work?") converts curiosity into a
+  qualified first message.
+
+---
+
+## cssOverrides recipes (tested)
+
+```css
+/* Dark card */
+[data-component="cta/root"]  { background:#121212; }
+[data-component="cta/title"] { color:#fff; }
+[data-component="cta/body"]  { color:#b3b3b3; }
+[data-component="cta/btn"][data-variant="secondary"] { background:#2a2a2a; color:#fff; }
+[data-component="cta/composer/input"] { background:#242424; border-color:#333; color:#fff; }
+[data-component="cta/dismiss_btn"] { color:#b3b3b3; }
+
+/* Coupon chip out of the body slot */
+[data-component="cta/body"] { font-family:ui-monospace,monospace; border:2px dashed #212A2F;
+  border-radius:10px; padding:10px 12px; text-align:center; font-weight:700;
+  letter-spacing:.14em; background:#F4F2EF; }
+
+/* Presence dot before the body line */
+[data-component="cta/body"]::before { content:''; display:inline-block; width:8px; height:8px;
+  border-radius:50%; background:#23A566; margin-right:6px; }
+
+/* Neo-brutalist */
+[data-component="cta/root"] { border-radius:24px; border:2px solid #241C15; box-shadow:6px 6px 0 #241C15; }
+[data-component="cta/btn"]  { border-radius:14px; border:2px solid #241C15; font-weight:700; }
+
+/* Tame a noisy image header into a banner strip */
+[data-component="cta/image"] { aspect-ratio:16/7; object-fit:cover; }
+
+/* Brand-gradient primary */
+[data-component="cta/btn"][data-variant="primary"] { background:linear-gradient(90deg,#E61E4D,#E31C5F,#D70466); }
+```
+
+---
+
+## Round 2 — re-review after the component pass (verdicts)
+
+All 10 re-rendered with the new defaults + v2 configs. Verdict: **converged.**
+
+- **Notion** — biggest transformation. The dark card now reads as part of the
+  hero instead of a sticker on it. Confirms: *match the surface you float over*
+  is the highest-leverage rule in the whole system.
+- **Nike** — proof that "minimal" works when type carries conviction: uppercase
+  italic 900-weight title + composer + nothing else reads unmistakably Nike.
+  A title override is the cheapest way to inject brand voice.
+- **Airbnb** — presence dot (body `::before`) + 32px avatars + the brand's real
+  gradient on the primary changed it from "widget with buttons" to "support is
+  right here". Social proof needs to *prove*, not decorate.
+- **Spotify / Linear / Netflix** — the three dark cards each read native
+  because the darks are the *brands' own* darks (#121212 / #0F1011 / #141414)
+  with matching hairline borders — never a generic "dark mode".
+- **Netflix** — `aspect-ratio: 16/7` banner crop tamed the noisy tile art;
+  image headers should be a strip, not a poster.
+- **Stripe / Shopify** — the light-card baseline: filled composer input +
+  grouped rhythm + soft ambient shadow carried both with zero overrides.
+- **Mailchimp / Allbirds** — the two "art direction" cards (neo-brutalist quiz,
+  coupon chip) survived the pass intact; distinctiveness lives in one signature
+  element per card, everything else stays quiet.
+
+Remaining nits consciously accepted: none visible at 1x. Stopping here —
+further rounds would optimize pixels the visitor never perceives.
+
+## The system, distilled (what shipped into component defaults)
+
+1. **Two-tier rhythm**: title+body 4px apart; groups 12-14px apart. Spacing IS
+   grouping.
+2. **17px/bold/snug title** — the headline is the card.
+3. **One primary** (semibold, brand fill); secondaries recede (muted fill,
+   medium weight). Radius family: card 16 / buttons 14 / composer & avatars
+   round.
+4. **Filled composer input** (secondary token, border only on focus) — an
+   invitation, not a wireframe.
+5. **Ambient elevation**: `0 12px 40px -8px rgba(0,0,0,.18)` + hairline
+   `black/5` border — floats on white, holds an edge on photos.
+6. **Dismiss X earns a scrim on imagery** (black/25 + white glyph +
+   backdrop-blur), stays quiet on flat cards.
+7. **Image headers are banners**: `max-h-44` + `object-cover` by default;
+   crop tighter per-brand with `aspect-ratio`.
+8. **Emoji ≤1 per card, only when it carries voice.**
+
+## Iteration log
+
+- **Round 0** — first 10 shipped with component defaults + naive per-brand
+  overrides. Screenshots reviewed; critique above.
+- **Round 1** — component design pass (rhythm, title scale, button hierarchy,
+  avatar presence, dismiss scrim on imagery, filled composer, ambient shadow)
+  + per-brand v2 configs (dark Notion, authentic Linear, Nike voice, Airbnb
+  gradient+presence, Netflix banner crop, copy de-emojied).
+- **Round 2** — full re-render + re-review. Converged; verdicts above.
+  Component changes committed to `aziz/feat/chat-cta`.

--- a/docs/cta-design-notebook.md
+++ b/docs/cta-design-notebook.md
@@ -110,6 +110,15 @@ Everything except `title` is opt-in. Restyle any slot via
 - Debug method that found it: measure `getBoundingClientRect()` of image vs
   card root inside the iframe, then diff the stylesheet rule against the
   element's computed style — visual inspection alone mis-attributes the cause.
+- **Host-page CSS can defeat ANY specificity you throw at it.** Recreating a
+  widget as bare host-DOM elements on open.cx: their stylesheet overrode our
+  border-radius/padding even against id-prefixed selectors and inline styles
+  (`!important` resets). Diagnosis trick: an inline-styled probe element whose
+  computed style doesn't match its inline value proves an `!important`
+  override, ending the specificity duel. The only real fix is an isolated
+  iframe (`srcdoc`) — which is exactly why the production widget renders every
+  surface (trigger, content, CTA card) inside iframes. Never ship a host-DOM
+  widget surface.
 
 ## cssOverrides recipes (tested)
 

--- a/docs/cta-design-notebook.md
+++ b/docs/cta-design-notebook.md
@@ -120,6 +120,29 @@ Everything except `title` is opt-in. Restyle any slot via
   surface (trigger, content, CTA card) inside iframes. Never ship a host-DOM
   widget surface.
 
+## The transform animation (gooey)
+
+Philosophy borrowed from Aceternity's gooey-input (Chris Coyier goo): two UI
+states connected by a liquid metaball morph.
+
+- **Filter on the blob layer only.** `feGaussianBlur` + high-contrast alpha
+  `feColorMatrix` on a background blob + corner droplet; the real card content
+  is a separate unfiltered layer that fades fast — live text must never sit in
+  the goo.
+- **Springs, not tweens.** Framer springs retarget mid-flight, which is what
+  makes rapid open/close safe: verified 4 toggles in 1.6s with clean settle.
+- **Hidden ≠ unmounted.** The card toggles `visibility`/`pointer-events`, never
+  `display:none` mid-animation and never unmounts — state (composer draft)
+  survives and the animation always has both endpoints alive.
+- **Reduced motion is the same variants with `duration: 0`** — one render
+  path, identical end states (asserted in tests).
+- **Verification trap:** Chrome's `--virtual-time-budget` starves framer's rAF
+  loop (one frame then freeze — two runs froze at *different* poses). Verify
+  JS-driven animation in REAL-time headless: block the `load` event with a
+  hanging image and let `--timeout` force the DOM dump; sample computed
+  transforms into data-attributes. Occluded interactive windows freeze rAF
+  too — headless is the reliable instrument.
+
 ## cssOverrides recipes (tested)
 
 ```css

--- a/packages/core/src/__tests__/context/message/inject-local-agent-message.spec.ts
+++ b/packages/core/src/__tests__/context/message/inject-local-agent-message.spec.ts
@@ -1,0 +1,170 @@
+import '../../api-caller.mock';
+
+import { ApiCaller } from '../../../api/api-caller';
+import { WidgetCtx } from '../../../context/widget.ctx';
+import type { MessageDto, SessionDto } from '../../../types/dtos';
+import type { WidgetAiMessage, WidgetMessageU } from '../../../types/messages';
+import { genUuid } from '../../../utils/uuid';
+import { TestUtils } from '../../test-utils';
+
+/* ------------------------------------------------------ */
+/*                        Helpers                         */
+/* ------------------------------------------------------ */
+
+const init = async (
+  config: Parameters<typeof WidgetCtx.initialize>[0]['config'] = { token: '' },
+) => {
+  const widgetCtx = await WidgetCtx.initialize({ config });
+  await TestUtils.sleep(20);
+  return widgetCtx;
+};
+
+const makeSessionDto = (overrides: Partial<SessionDto> = {}): SessionDto => ({
+  id: genUuid(),
+  ticketNumber: 1,
+  assignee: { kind: 'ai', name: null, avatarUrl: null },
+  channel: '',
+  createdAt: new Date().toISOString(),
+  isHandedOff: false,
+  isOpened: true,
+  isVerified: false,
+  lastMessage: '',
+  updatedAt: new Date().toISOString(),
+  modeId: null,
+  latestStateCheckpointPayload: null,
+  ...overrides,
+});
+
+const aiHistoryItem = (id = genUuid(), text = 'ai-text'): MessageDto => ({
+  type: 'message',
+  publicId: id,
+  content: { text },
+  sender: { kind: 'ai', name: null, avatar: null },
+  sentAt: new Date().toISOString(),
+  attachments: null,
+  actionCalls: null,
+  systemMessagePayload: { type: 'none' },
+});
+
+/** Sets the session so `ActiveSessionPollingCtx` starts and fires immediately. */
+const triggerPoll = async (widgetCtx: WidgetCtx, session: SessionDto) => {
+  widgetCtx.sessionCtx.sessionState.setPartial({ session });
+  await TestUtils.sleep(50);
+};
+
+const messagesOf = (widgetCtx: WidgetCtx): WidgetMessageU[] =>
+  widgetCtx.messageCtx.state.get().messages;
+
+/* ------------------------------------------------------ */
+/*                         Tests                          */
+/* ------------------------------------------------------ */
+
+suite('messageCtx.injectLocalAgentMessage', () => {
+  test('appends a correctly-shaped AI bot_message bubble', async () => {
+    const widgetCtx = await init();
+    widgetCtx.messageCtx.injectLocalAgentMessage(
+      'Onboarding takes ~2 minutes.',
+    );
+
+    const messages = messagesOf(widgetCtx);
+    expect(messages).toHaveLength(1);
+    const msg = messages[0] as WidgetAiMessage;
+    expect(msg.type).toBe('AI');
+    expect(msg.component).toBe('bot_message');
+    expect(msg.data.message).toBe('Onboarding takes ~2 minutes.');
+    expect(typeof msg.id).toBe('string');
+    expect(msg.id.length).toBeGreaterThan(0);
+    expect(typeof msg.timestamp).toBe('string');
+  });
+
+  test('uses config.bot for the agent identity when provided', async () => {
+    const widgetCtx = await init({
+      token: '',
+      bot: { name: 'Volt', avatarUrl: null },
+    });
+    widgetCtx.messageCtx.injectLocalAgentMessage('hi');
+    const msg = messagesOf(widgetCtx)[0] as WidgetAiMessage;
+    expect(msg.agent?.name).toBe('Volt');
+    expect(msg.agent?.isAi).toBe(true);
+  });
+
+  test('trims the message text', async () => {
+    const widgetCtx = await init();
+    widgetCtx.messageCtx.injectLocalAgentMessage('  hello  ');
+    expect((messagesOf(widgetCtx)[0] as WidgetAiMessage).data.message).toBe(
+      'hello',
+    );
+  });
+
+  test('no-ops on empty or whitespace-only input', async () => {
+    const widgetCtx = await init();
+    widgetCtx.messageCtx.injectLocalAgentMessage('');
+    widgetCtx.messageCtx.injectLocalAgentMessage('   ');
+    expect(messagesOf(widgetCtx)).toHaveLength(0);
+  });
+
+  test('does NOT call the API (purely client-side)', async () => {
+    const widgetCtx = await init();
+    widgetCtx.messageCtx.injectLocalAgentMessage('canned');
+    expect(ApiCaller.prototype.sendMessage).not.toHaveBeenCalled();
+  });
+
+  test('appends after existing messages and preserves order across injects', async () => {
+    const widgetCtx = await init();
+    widgetCtx.messageCtx.state.setPartial({
+      messages: [
+        {
+          id: 'u1',
+          type: 'USER',
+          content: 'q',
+          deliveredAt: null,
+          timestamp: null,
+        },
+      ],
+    });
+    widgetCtx.messageCtx.injectLocalAgentMessage('first');
+    widgetCtx.messageCtx.injectLocalAgentMessage('second');
+
+    const msgs = messagesOf(widgetCtx);
+    expect(msgs.map((m) => m.type)).toEqual(['USER', 'AI', 'AI']);
+    expect((msgs[1] as WidgetAiMessage).data.message).toBe('first');
+    expect((msgs[2] as WidgetAiMessage).data.message).toBe('second');
+  });
+
+  test('assigns a unique id to each injected bubble', async () => {
+    const widgetCtx = await init();
+    widgetCtx.messageCtx.injectLocalAgentMessage('a');
+    widgetCtx.messageCtx.injectLocalAgentMessage('b');
+    const [m1, m2] = messagesOf(widgetCtx);
+    expect(m1!.id).not.toBe(m2!.id);
+  });
+
+  test('survives a polling cycle (poller merges by id, never replaces)', async () => {
+    const widgetCtx = await init();
+    const sessionId = genUuid();
+    const polledAiId = genUuid();
+    TestUtils.mock.ApiCaller.pollSessionAndHistory(ApiCaller, {
+      data: {
+        session: makeSessionDto({ id: sessionId }),
+        history: [aiHistoryItem(polledAiId, 'from server')],
+      },
+    });
+
+    widgetCtx.messageCtx.injectLocalAgentMessage('canned answer');
+    const injectedId = messagesOf(widgetCtx)[0]!.id;
+
+    await triggerPoll(widgetCtx, makeSessionDto({ id: sessionId }));
+
+    const ids = messagesOf(widgetCtx).map((m) => m.id);
+    expect(ids).toContain(injectedId); // injected bubble survived the poll
+    expect(ids).toContain(polledAiId); // server message was appended alongside
+  });
+
+  test('is cleared by widgetCtx.resetChat()', async () => {
+    const widgetCtx = await init();
+    widgetCtx.messageCtx.injectLocalAgentMessage('canned');
+    expect(messagesOf(widgetCtx)).toHaveLength(1);
+    widgetCtx.resetChat();
+    expect(messagesOf(widgetCtx)).toHaveLength(0);
+  });
+});

--- a/packages/core/src/__tests__/context/widget/composer-draft.spec.ts
+++ b/packages/core/src/__tests__/context/widget/composer-draft.spec.ts
@@ -1,0 +1,57 @@
+import '../../api-caller.mock';
+
+import { WidgetCtx } from '../../../context/widget.ctx';
+import { TestUtils } from '../../test-utils';
+
+const init = async () => {
+  const widgetCtx = await WidgetCtx.initialize({ config: { token: '' } });
+  await TestUtils.sleep(20);
+  return widgetCtx;
+};
+
+suite('composer draft', () => {
+  test('defaults to an empty string', async () => {
+    const widgetCtx = await init();
+    expect(widgetCtx.composerDraft.get()).toBe('');
+  });
+
+  test('setComposerDraft sets the draft text', async () => {
+    const widgetCtx = await init();
+    widgetCtx.setComposerDraft('How do I withdraw earnings?');
+    expect(widgetCtx.composerDraft.get()).toBe('How do I withdraw earnings?');
+  });
+
+  test('setComposerDraft can be overwritten and cleared', async () => {
+    const widgetCtx = await init();
+    widgetCtx.setComposerDraft('first');
+    widgetCtx.setComposerDraft('second');
+    expect(widgetCtx.composerDraft.get()).toBe('second');
+    widgetCtx.setComposerDraft('');
+    expect(widgetCtx.composerDraft.get()).toBe('');
+  });
+
+  test('resetChat() clears the draft (preserves "draft clears on new chat")', async () => {
+    const widgetCtx = await init();
+    widgetCtx.setComposerDraft('a pending question');
+    widgetCtx.resetChat();
+    expect(widgetCtx.composerDraft.get()).toBe('');
+  });
+
+  test('notifies subscribers when the draft changes', async () => {
+    const widgetCtx = await init();
+    const seen: string[] = [];
+    widgetCtx.composerDraft.subscribe((v) => seen.push(v));
+    widgetCtx.setComposerDraft('x');
+    widgetCtx.setComposerDraft('xy');
+    expect(seen).toEqual(['x', 'xy']);
+  });
+
+  test('does not notify when the draft is set to the same value', async () => {
+    const widgetCtx = await init();
+    widgetCtx.setComposerDraft('same');
+    const seen: string[] = [];
+    widgetCtx.composerDraft.subscribe((v) => seen.push(v));
+    widgetCtx.setComposerDraft('same');
+    expect(seen).toEqual([]);
+  });
+});

--- a/packages/core/src/__tests__/context/widget/cta-override.spec.ts
+++ b/packages/core/src/__tests__/context/widget/cta-override.spec.ts
@@ -1,0 +1,43 @@
+import '../../api-caller.mock';
+
+import { WidgetCtx } from '../../../context/widget.ctx';
+import { TestUtils } from '../../test-utils';
+
+const init = async () => {
+  const widgetCtx = await WidgetCtx.initialize({ config: { token: '' } });
+  await TestUtils.sleep(20);
+  return widgetCtx;
+};
+
+suite('cta override state', () => {
+  test('defaults to null (rules decide)', async () => {
+    const widgetCtx = await init();
+    expect(widgetCtx.ctaOverride.get()).toBeNull();
+  });
+
+  test('setCtaOverride sets show, hide, and back to null', async () => {
+    const widgetCtx = await init();
+    widgetCtx.setCtaOverride('show');
+    expect(widgetCtx.ctaOverride.get()).toBe('show');
+    widgetCtx.setCtaOverride('hide');
+    expect(widgetCtx.ctaOverride.get()).toBe('hide');
+    widgetCtx.setCtaOverride(null);
+    expect(widgetCtx.ctaOverride.get()).toBeNull();
+  });
+
+  test('notifies subscribers on change', async () => {
+    const widgetCtx = await init();
+    const seen: Array<'show' | 'hide' | null> = [];
+    widgetCtx.ctaOverride.subscribe((v) => seen.push(v));
+    widgetCtx.setCtaOverride('show');
+    widgetCtx.setCtaOverride('hide');
+    expect(seen).toEqual(['show', 'hide']);
+  });
+
+  test('resetChat() does NOT clear the override (CTA is not chat state)', async () => {
+    const widgetCtx = await init();
+    widgetCtx.setCtaOverride('show');
+    widgetCtx.resetChat();
+    expect(widgetCtx.ctaOverride.get()).toBe('show');
+  });
+});

--- a/packages/core/src/__tests__/context/widget/cta-visible.spec.ts
+++ b/packages/core/src/__tests__/context/widget/cta-visible.spec.ts
@@ -1,0 +1,50 @@
+import '../../api-caller.mock';
+
+import { WidgetCtx } from '../../../context/widget.ctx';
+import { TestUtils } from '../../test-utils';
+
+const init = async () => {
+  const widgetCtx = await WidgetCtx.initialize({ config: { token: '' } });
+  await TestUtils.sleep(20);
+  return widgetCtx;
+};
+
+suite('cta visible state (published by the card, read by the launcher)', () => {
+  test('defaults to false (no card shown yet)', async () => {
+    const widgetCtx = await init();
+    expect(widgetCtx.ctaVisible.get()).toBe(false);
+  });
+
+  test('setCtaVisible toggles true and back to false', async () => {
+    const widgetCtx = await init();
+    widgetCtx.setCtaVisible(true);
+    expect(widgetCtx.ctaVisible.get()).toBe(true);
+    widgetCtx.setCtaVisible(false);
+    expect(widgetCtx.ctaVisible.get()).toBe(false);
+  });
+
+  test('notifies subscribers on change (launcher swap in transform mode)', async () => {
+    const widgetCtx = await init();
+    const seen: boolean[] = [];
+    widgetCtx.ctaVisible.subscribe((v) => seen.push(v));
+    widgetCtx.setCtaVisible(true);
+    widgetCtx.setCtaVisible(false);
+    expect(seen).toEqual([true, false]);
+  });
+
+  test('does not notify on same-value writes (rapid open/close stays quiet)', async () => {
+    const widgetCtx = await init();
+    widgetCtx.setCtaVisible(true);
+    const seen: boolean[] = [];
+    widgetCtx.ctaVisible.subscribe((v) => seen.push(v));
+    widgetCtx.setCtaVisible(true);
+    expect(seen).toEqual([]);
+  });
+
+  test('resetChat() does NOT clear it (launcher state, not chat state)', async () => {
+    const widgetCtx = await init();
+    widgetCtx.setCtaVisible(true);
+    widgetCtx.resetChat();
+    expect(widgetCtx.ctaVisible.get()).toBe(true);
+  });
+});

--- a/packages/core/src/__tests__/cta/cta-visibility.spec.ts
+++ b/packages/core/src/__tests__/cta/cta-visibility.spec.ts
@@ -1,0 +1,117 @@
+import {
+  ctaUrlMatches,
+  isCtaDismissed,
+  parseCtaDismissalRecord,
+  resolveCtaVisible,
+} from '../../cta/cta-visibility';
+
+const DAY = 86_400_000;
+
+suite('parseCtaDismissalRecord', () => {
+  test('null / empty raw → null', () => {
+    expect(parseCtaDismissalRecord(null)).toBeNull();
+    expect(parseCtaDismissalRecord('')).toBeNull();
+  });
+
+  test('valid record round-trips', () => {
+    expect(parseCtaDismissalRecord('{"dismissedAt":123}')).toEqual({
+      dismissedAt: 123,
+    });
+  });
+
+  test('malformed JSON → null (does not throw)', () => {
+    expect(parseCtaDismissalRecord('{oops')).toBeNull();
+  });
+
+  test('wrong shape → null (string timestamp, missing key, non-object)', () => {
+    expect(parseCtaDismissalRecord('{"dismissedAt":"123"}')).toBeNull();
+    expect(parseCtaDismissalRecord('{}')).toBeNull();
+    expect(parseCtaDismissalRecord('42')).toBeNull();
+  });
+});
+
+suite('isCtaDismissed', () => {
+  test('no record → not dismissed', () => {
+    expect(isCtaDismissed(null, undefined, 1000)).toBe(false);
+  });
+
+  test('record + no dismissForDays → dismissed forever', () => {
+    expect(isCtaDismissed({ dismissedAt: 0 }, undefined, 1000 * DAY)).toBe(
+      true,
+    );
+  });
+
+  test('record within the dismissForDays window → still dismissed', () => {
+    expect(isCtaDismissed({ dismissedAt: 0 }, 7, 6 * DAY)).toBe(true);
+  });
+
+  test('record past the dismissForDays window → shown again', () => {
+    expect(isCtaDismissed({ dismissedAt: 0 }, 7, 8 * DAY)).toBe(false);
+  });
+});
+
+suite('ctaUrlMatches', () => {
+  test('no urlMatch → matches everything', () => {
+    expect(ctaUrlMatches(undefined, 'https://x.com/any')).toBe(true);
+  });
+
+  test('substring hit and miss', () => {
+    expect(ctaUrlMatches('/pricing', 'https://x.com/pricing?a=1')).toBe(true);
+    expect(ctaUrlMatches('/pricing', 'https://x.com/docs')).toBe(false);
+  });
+});
+
+suite('resolveCtaVisible', () => {
+  const base = {
+    hasCta: true,
+    isWidgetOpen: false,
+    override: null,
+    dismissed: false,
+    urlMatches: true,
+    delayElapsed: true,
+  } as const;
+
+  test('default happy path → visible', () => {
+    expect(resolveCtaVisible({ ...base })).toBe(true);
+  });
+
+  test('no cta config → hidden even with override "show"', () => {
+    expect(resolveCtaVisible({ ...base, hasCta: false, override: 'show' })).toBe(
+      false,
+    );
+  });
+
+  test('widget open → hidden even with override "show"', () => {
+    expect(
+      resolveCtaVisible({ ...base, isWidgetOpen: true, override: 'show' }),
+    ).toBe(false);
+  });
+
+  test('override "hide" beats everything else', () => {
+    expect(resolveCtaVisible({ ...base, override: 'hide' })).toBe(false);
+  });
+
+  test('override "show" beats dismissal, url mismatch, and pending delay', () => {
+    expect(
+      resolveCtaVisible({
+        ...base,
+        override: 'show',
+        dismissed: true,
+        urlMatches: false,
+        delayElapsed: false,
+      }),
+    ).toBe(true);
+  });
+
+  test('dismissed → hidden', () => {
+    expect(resolveCtaVisible({ ...base, dismissed: true })).toBe(false);
+  });
+
+  test('url mismatch → hidden', () => {
+    expect(resolveCtaVisible({ ...base, urlMatches: false })).toBe(false);
+  });
+
+  test('delay not yet elapsed → hidden', () => {
+    expect(resolveCtaVisible({ ...base, delayElapsed: false })).toBe(false);
+  });
+});

--- a/packages/core/src/__tests__/cta/cta-visibility.spec.ts
+++ b/packages/core/src/__tests__/cta/cta-visibility.spec.ts
@@ -48,6 +48,10 @@ suite('isCtaDismissed', () => {
   test('record past the dismissForDays window → shown again', () => {
     expect(isCtaDismissed({ dismissedAt: 0 }, 7, 8 * DAY)).toBe(false);
   });
+
+  test('exact window boundary → shown again (strict comparison)', () => {
+    expect(isCtaDismissed({ dismissedAt: 0 }, 7, 7 * DAY)).toBe(false);
+  });
 });
 
 suite('ctaUrlMatches', () => {

--- a/packages/core/src/context/message.ctx.ts
+++ b/packages/core/src/context/message.ctx.ts
@@ -66,13 +66,47 @@ export class MessageCtx {
   };
 
   /**
+   * Appends a client-only AI ("agent") bubble to the transcript WITHOUT contacting
+   * the server. Used by the host-facing `presentAnswer` trigger to show a canned
+   * answer. The bubble carries a client-generated id, so the active-session poller
+   * (which only appends server messages and dedupes by id) never removes or
+   * duplicates it. It is ephemeral: not persisted, not part of the AI's context,
+   * and cleared by `reset()` / `resetChat()`. No-ops on empty input.
+   */
+  injectLocalAgentMessage = (message: string): void => {
+    const trimmed = message.trim();
+    if (!trimmed) return;
+    const aiMessage: WidgetAiMessage = {
+      id: genUuid(),
+      type: 'AI',
+      timestamp: new Date().toISOString(),
+      component: 'bot_message',
+      agent: this.config.bot
+        ? {
+            name: this.config.bot.name || '',
+            isAi: true,
+            // Let avatar be resolved from config at render time (mirror toBotMessage)
+            avatarUrl: null,
+            avatar: null,
+            id: null,
+          }
+        : undefined,
+      data: { message: trimmed },
+    };
+    this.state.setPartial({
+      messages: [...this.state.get().messages, aiMessage],
+    });
+  };
+
+  /**
    * Fires `config.hooks.onMessageReceived` for AI or human-agent messages exactly
    * once per id. Safe to call from any path that ingests messages from the server
    * (send-message response, polling, initial history fetch).
    */
   dispatchToOnMessageReceivedHook = (message: WidgetMessageU): void => {
     if (message.type === 'USER') return;
-    if (this.messageIdsDispatchedToOnMessageReceivedHook.has(message.id)) return;
+    if (this.messageIdsDispatchedToOnMessageReceivedHook.has(message.id))
+      return;
     const session = this.sessionCtx.sessionState.get().session;
     if (!session) return;
     this.messageIdsDispatchedToOnMessageReceivedHook.add(message.id);
@@ -166,7 +200,9 @@ export class MessageCtx {
                   data: {
                     message: m.message,
                   },
-                  agent: this.config.bot ? { ...this.config.bot, isAi: true, id: null } : undefined,
+                  agent: this.config.bot
+                    ? { ...this.config.bot, isAi: true, id: null }
+                    : undefined,
                 }) satisfies WidgetAiMessage,
             )
         : [];
@@ -260,7 +296,8 @@ export class MessageCtx {
         }
       } else {
         const errorMessage = this.toBotErrorMessage(
-          data?.error?.message || 'Something went wrong. Please refresh the page or try again.',
+          data?.error?.message ||
+            'Something went wrong. Please refresh the page or try again.',
         );
         const currentMessages = this.state.get().messages;
         this.state.setPartial({

--- a/packages/core/src/context/widget.ctx.ts
+++ b/packages/core/src/context/widget.ctx.ts
@@ -39,6 +39,14 @@ export class WidgetCtx {
    */
   public ctaOverride = new PrimitiveState<CtaOverride>(null);
 
+  /**
+   * The CTA card's CURRENT resolved visibility, published by the card
+   * container (single source of truth: `resolveCtaVisible`). Read by the
+   * launcher so `cta.mode: 'transform'` can swap the bubble for the card
+   * without re-deriving the rules.
+   */
+  public ctaVisible = new PrimitiveState<boolean>(false);
+
   public org: {
     id: string;
     name: string;
@@ -156,6 +164,10 @@ export class WidgetCtx {
 
   setCtaOverride = (value: CtaOverride) => {
     this.ctaOverride.set(value);
+  };
+
+  setCtaVisible = (value: boolean) => {
+    this.ctaVisible.set(value);
   };
 
   resetChat = () => {

--- a/packages/core/src/context/widget.ctx.ts
+++ b/packages/core/src/context/widget.ctx.ts
@@ -9,6 +9,7 @@ import { MessageCtx } from './message.ctx';
 import { RouterCtx } from './router.ctx';
 import { SessionCtx } from './session.ctx';
 import { StorageCtx } from './storage.ctx';
+import { PrimitiveState } from '../utils/PrimitiveState';
 
 export class WidgetCtx {
   public config: WidgetConfig;
@@ -21,6 +22,14 @@ export class WidgetCtx {
   public routerCtx: RouterCtx;
   public storageCtx?: StorageCtx;
   public modes: ModeDto[] = [];
+
+  /**
+   * The chat composer's draft text. Lifted out of the input component so it can
+   * be set programmatically (host-facing `prefill` trigger) and read/written by
+   * `ChatInput`. Cleared on `resetChat()` to preserve the prior "draft clears on
+   * new chat" behaviour.
+   */
+  public composerDraft = new PrimitiveState<string>('');
 
   public org: {
     id: string;
@@ -133,8 +142,13 @@ export class WidgetCtx {
     });
   };
 
+  setComposerDraft = (text: string) => {
+    this.composerDraft.set(text);
+  };
+
   resetChat = () => {
     this.sessionCtx.reset();
     this.messageCtx.reset();
+    this.composerDraft.reset();
   };
 }

--- a/packages/core/src/context/widget.ctx.ts
+++ b/packages/core/src/context/widget.ctx.ts
@@ -10,6 +10,7 @@ import { RouterCtx } from './router.ctx';
 import { SessionCtx } from './session.ctx';
 import { StorageCtx } from './storage.ctx';
 import { PrimitiveState } from '../utils/PrimitiveState';
+import type { CtaOverride } from '../cta/cta-visibility';
 
 export class WidgetCtx {
   public config: WidgetConfig;
@@ -30,6 +31,13 @@ export class WidgetCtx {
    * new chat" behaviour.
    */
   public composerDraft = new PrimitiveState<string>('');
+
+  /**
+   * Host/API-driven override of the CTA card's visibility (`showCta()` /
+   * `hideCta()`). `null` = the config rules decide. Deliberately NOT cleared
+   * by `resetChat()` — the CTA is launcher state, not chat state.
+   */
+  public ctaOverride = new PrimitiveState<CtaOverride>(null);
 
   public org: {
     id: string;
@@ -144,6 +152,10 @@ export class WidgetCtx {
 
   setComposerDraft = (text: string) => {
     this.composerDraft.set(text);
+  };
+
+  setCtaOverride = (value: CtaOverride) => {
+    this.ctaOverride.set(value);
   };
 
   resetChat = () => {

--- a/packages/core/src/cta/cta-visibility.ts
+++ b/packages/core/src/cta/cta-visibility.ts
@@ -1,0 +1,67 @@
+/** Host/API-driven override of the CTA card's visibility. */
+export type CtaOverride = 'show' | 'hide' | null;
+
+/** What we persist (JSON) in storage when the visitor dismisses the card. */
+export type CtaDismissalRecord = { dismissedAt: number };
+
+export function parseCtaDismissalRecord(
+  raw: string | null,
+): CtaDismissalRecord | null {
+  if (!raw) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      parsed !== null &&
+      typeof parsed === 'object' &&
+      'dismissedAt' in parsed &&
+      typeof parsed.dismissedAt === 'number'
+    ) {
+      return { dismissedAt: parsed.dismissedAt };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+const DAY_MS = 86_400_000;
+
+/**
+ * `dismissForDays === undefined` means a dismissal is permanent; otherwise the
+ * card comes back once the window has elapsed.
+ */
+export function isCtaDismissed(
+  record: CtaDismissalRecord | null,
+  dismissForDays: number | undefined,
+  now: number,
+): boolean {
+  if (!record) return false;
+  if (dismissForDays === undefined) return true;
+  return now < record.dismissedAt + dismissForDays * DAY_MS;
+}
+
+export function ctaUrlMatches(
+  urlMatch: string | undefined,
+  href: string,
+): boolean {
+  return urlMatch === undefined || href.includes(urlMatch);
+}
+
+/**
+ * Single source of truth for whether the CTA card renders. An open widget
+ * always wins (the card never overlaps the chat); `hide` beats `show`; `show`
+ * bypasses dismissal, URL, and delay rules.
+ */
+export function resolveCtaVisible(input: {
+  hasCta: boolean;
+  isWidgetOpen: boolean;
+  override: CtaOverride;
+  dismissed: boolean;
+  urlMatches: boolean;
+  delayElapsed: boolean;
+}): boolean {
+  if (!input.hasCta || input.isWidgetOpen) return false;
+  if (input.override === 'hide') return false;
+  if (input.override === 'show') return true;
+  return !input.dismissed && input.urlMatches && input.delayElapsed;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -50,6 +50,14 @@ export { PrimitiveState } from './utils/PrimitiveState';
 export { isExhaustive } from './utils/is-exhaustive';
 
 export {
+  ctaUrlMatches,
+  isCtaDismissed,
+  parseCtaDismissalRecord,
+  resolveCtaVisible,
+} from './cta/cta-visibility';
+export type { CtaDismissalRecord, CtaOverride } from './cta/cta-visibility';
+
+export {
   type Language,
   type TranslationInterface,
   type TranslationKeyU,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,6 +32,8 @@ export type {
   ModeComponentProps,
   CustomComponent,
   CustomComponentProps,
+  CtaButton,
+  CtaConfig,
 } from './types/widget-config';
 export type { ExternalStorage } from './types/external-storage';
 export type { OpenCxComponentNameU } from './types/component-name';

--- a/packages/core/src/types/component-name.ts
+++ b/packages/core/src/types/component-name.ts
@@ -9,6 +9,20 @@ export type OpenCxComponentNameU =
   | 'trigger/btn'
 
   /* ------------------------------------------------------ */
+  /*                         CTA Card                       */
+  /* ------------------------------------------------------ */
+  | 'cta/root'
+  | 'cta/dismiss_btn'
+  | 'cta/image'
+  | 'cta/title'
+  | 'cta/body'
+  | 'cta/avatars'
+  | 'cta/btn'
+  | 'cta/composer/root'
+  | 'cta/composer/input'
+  | 'cta/composer/send_btn'
+
+  /* ------------------------------------------------------ */
   /*                     Sessions Screen                    */
   /* ------------------------------------------------------ */
   | 'sessions/root'

--- a/packages/core/src/types/component-name.ts
+++ b/packages/core/src/types/component-name.ts
@@ -21,6 +21,7 @@ export type OpenCxComponentNameU =
   | 'cta/composer/root'
   | 'cta/composer/input'
   | 'cta/composer/send_btn'
+  | 'cta/goo_blob'
 
   /* ------------------------------------------------------ */
   /*                     Sessions Screen                    */

--- a/packages/core/src/types/widget-config.ts
+++ b/packages/core/src/types/widget-config.ts
@@ -224,6 +224,51 @@ export type CustomComponent = (
   props: CustomComponentProps,
 ) => ReturnType<typeof React.createElement> | null;
 
+export type CtaButton =
+  | { text: string; action: 'open-chat'; variant?: 'primary' | 'secondary' }
+  | {
+      text: string;
+      /** `ask` sends `message` immediately in a fresh chat; `prefill` only drafts it. */
+      action: 'ask' | 'prefill';
+      message: string;
+      variant?: 'primary' | 'secondary';
+    }
+  | {
+      text: string;
+      action: 'url';
+      url: string;
+      /** @default true */
+      openInNewTab?: boolean;
+      variant?: 'primary' | 'secondary';
+    };
+
+export type CtaConfig = {
+  /** Card headline. */
+  title: string;
+  /** Optional supporting copy under the title. */
+  body?: string;
+  /** Optional image rendered at the top of the card. */
+  imageUrl?: string;
+  /** Optional row of small round avatars (e.g. the support team). */
+  avatarUrls?: string[];
+  /** Action buttons, rendered in order. */
+  buttons?: CtaButton[];
+  /**
+   * Renders a message input directly in the card; submitting starts a fresh
+   * chat with the typed text (same behavior as an `ask` button).
+   */
+  composer?: { placeholder?: string };
+  /**
+   * Re-show the card this many days after the visitor dismisses it.
+   * Omit = once dismissed, never shown again (per browser).
+   */
+  dismissForDays?: number;
+  /** Delay before the card appears. @default 0 */
+  showAfterSeconds?: number;
+  /** Only show when `location.href` contains this substring. Omit = all pages. */
+  urlMatch?: string;
+};
+
 export interface WidgetConfig {
   /**
    * Your organization's widget token.
@@ -270,6 +315,13 @@ export interface WidgetConfig {
    * @default undefined
    */
   openAfterNSeconds?: number;
+
+  /**
+   * A proactive CTA/teaser card shown near the launcher while the widget is
+   * closed. Drive it programmatically with `showCta()` / `hideCta()`.
+   * @default undefined
+   */
+  cta?: CtaConfig;
 
   /**
    * A custom vanilla stylesheet to override the default styles. See {@link OpenCxComponentNameU} for available component names.
@@ -536,6 +588,19 @@ export interface WidgetConfig {
       message: WidgetMessageU;
       session: SessionDto;
     }) => void;
+
+    /** Fires the first time the CTA card becomes visible on this page load. */
+    onCtaDisplayed?: () => void;
+
+    /** Fires when a CTA button or its composer is used. */
+    onCtaClicked?: (ctx: {
+      action: 'open-chat' | 'ask' | 'prefill' | 'url' | 'composer';
+      /** Button index; `undefined` for the composer. */
+      index?: number;
+    }) => void;
+
+    /** Fires when the visitor dismisses the card with the X button. */
+    onCtaDismissed?: () => void;
   };
 
   /**

--- a/packages/core/src/types/widget-config.ts
+++ b/packages/core/src/types/widget-config.ts
@@ -243,6 +243,16 @@ export type CtaButton =
     };
 
 export type CtaConfig = {
+  /**
+   * How the card relates to the launcher bubble.
+   * - `'coexist'` (default): the card floats above the launcher.
+   * - `'transform'`: the card REPLACES the launcher — opening the widget swaps
+   *   the card for the panel, closing swaps back (card state preserved), and
+   *   dismissing the card falls back to the launcher bubble.
+   * @default 'coexist'
+   */
+  mode?: 'coexist' | 'transform';
+
   /** Card headline. */
   title: string;
   /** Optional supporting copy under the title. */

--- a/packages/embed/README.md
+++ b/packages/embed/README.md
@@ -56,6 +56,11 @@ initOpenScript(options);
 
 ### Rule options
 
+- `mode: 'transform'` — the card REPLACES the launcher bubble instead of
+  floating above it: opening the widget swaps the card for the chat panel,
+  closing swaps back (the card keeps its state, including a half-typed
+  composer draft), and dismissing the card falls back to the launcher bubble
+  so the visitor always has an entry point. Default is `'coexist'`.
 - `dismissForDays` — re-show the card this many days after the visitor
   dismisses it. Omit and a dismissal is permanent (per browser).
 - `showAfterSeconds` — delay before the card first appears. Defaults to `0`.

--- a/packages/embed/README.md
+++ b/packages/embed/README.md
@@ -3,3 +3,95 @@
 The default React widget. Embeddable in HTML.
 
 For more information, check [the documentation](https://docs.open.cx/widget/getting-started)
+
+## CTA card
+
+A declarative CTA/teaser card shown near the launcher while the widget is
+closed — the "Crisp/Text-style" proactive card. Configure it with a `cta`
+object on the options you pass to `initOpenScript`:
+
+```js
+const options = {
+  token: 'your-widget-token',
+  cta: {
+    title: 'Do you have any questions? 😀',
+    body: 'The team is online and typically replies in minutes.',
+    avatarUrls: [
+      'https://i.pravatar.cc/56?img=1',
+      'https://i.pravatar.cc/56?img=2',
+      'https://i.pravatar.cc/56?img=3',
+    ],
+    buttons: [
+      // Opens the widget.
+      { text: 'Chat with the team', action: 'open-chat' },
+      // Opens a fresh chat and SENDS the message immediately.
+      {
+        text: 'How do earnings work?',
+        action: 'ask',
+        message: 'How do earnings work?',
+        variant: 'secondary',
+      },
+      // `prefill` drafts the message in the composer without sending.
+      // `url` opens a link (`openInNewTab` defaults to true).
+      {
+        text: 'Sign up free',
+        action: 'url',
+        url: 'https://open.cx',
+        variant: 'secondary',
+      },
+    ],
+    // Renders an inline input; submitting starts a fresh chat with the text.
+    composer: { placeholder: 'Write a message…' },
+    dismissForDays: 7,
+  },
+  hooks: {
+    onCtaDisplayed: () => console.log('[cta] displayed'),
+    onCtaClicked: (ctx) => console.log('[cta] clicked', ctx),
+    onCtaDismissed: () => console.log('[cta] dismissed'),
+  },
+};
+
+initOpenScript(options);
+```
+
+### Rule options
+
+- `dismissForDays` — re-show the card this many days after the visitor
+  dismisses it. Omit and a dismissal is permanent (per browser).
+- `showAfterSeconds` — delay before the card first appears. Defaults to `0`.
+- `urlMatch` — only show the card when `location.href` contains this
+  substring. Omit to show on all pages.
+
+### Hooks
+
+- `onCtaDisplayed()` — fires the first time the card becomes visible on this
+  page load.
+- `onCtaClicked({ action, index })` — fires on a button or composer use;
+  `action` is `'open-chat' | 'ask' | 'prefill' | 'url' | 'composer'` and
+  `index` is the button index (`undefined` for the composer).
+- `onCtaDismissed()` — fires when the visitor closes the card with the X.
+
+### Host control
+
+Drive the card programmatically from the page via `window.opencxWidget`:
+
+- `window.opencxWidget.showCta()` — force-show the card, bypassing the
+  dismissal, `urlMatch`, and `showAfterSeconds` rules (no-op while the widget
+  is open).
+- `window.opencxWidget.hideCta()` — force-hide the card until `showCta()` or a
+  reload.
+
+### Styling
+
+Every part of the card carries a `data-component` name you can target with
+`cssOverrides`: `cta/root`, `cta/dismiss_btn`, `cta/image`, `cta/title`,
+`cta/body`, `cta/avatars`, `cta/btn`, `cta/composer/root`,
+`cta/composer/input`, and `cta/composer/send_btn`.
+
+```js
+const options = {
+  token: 'your-widget-token',
+  cta: { title: 'Need a hand?' },
+  cssOverrides: '[data-component="cta/title"] { color: orangered; }',
+};
+```

--- a/packages/embed/index.html
+++ b/packages/embed/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <script type="module" src="index.tsx"></script>
+    <script type="module" src="/src/index.tsx"></script>
     <title>OpenCX Widget</title>
     <style>
       body {
@@ -13,9 +13,46 @@
         width: 100vw;
         background-color: white;
       }
-
-      
     </style>
+    <script>
+      const options = {
+        token: '232d2c4e33db9ff8372c5fef8d649cb0',
+        cta: {
+          title: 'Do you have any questions? 😀',
+          body: 'The team is online and typically replies in minutes.',
+          avatarUrls: [
+            'https://i.pravatar.cc/56?img=1',
+            'https://i.pravatar.cc/56?img=2',
+            'https://i.pravatar.cc/56?img=3',
+          ],
+          buttons: [
+            { text: 'Chat with the team', action: 'open-chat' },
+            {
+              text: 'How do earnings work?',
+              action: 'ask',
+              message: 'How do earnings work?',
+              variant: 'secondary',
+            },
+            {
+              text: 'Sign up free',
+              action: 'url',
+              url: 'https://open.cx',
+              variant: 'secondary',
+            },
+          ],
+          composer: { placeholder: 'Write a message…' },
+          dismissForDays: 7,
+        },
+        hooks: {
+          onCtaDisplayed: () => console.log('[cta] displayed'),
+          onCtaClicked: (ctx) => console.log('[cta] clicked', ctx),
+          onCtaDismissed: () => console.log('[cta] dismissed'),
+        },
+      };
+      window.addEventListener('DOMContentLoaded', () => {
+        initOpenScript(options);
+      });
+    </script>
   </head>
 
   <body>

--- a/packages/embed/index.html
+++ b/packages/embed/index.html
@@ -18,6 +18,7 @@
       const options = {
         token: '232d2c4e33db9ff8372c5fef8d649cb0',
         cta: {
+          mode: 'transform',
           title: 'Do you have any questions? 😀',
           body: 'The team is online and typically replies in minutes.',
           avatarUrls: [

--- a/packages/embed/src/__tests__/triggers.spec.ts
+++ b/packages/embed/src/__tests__/triggers.spec.ts
@@ -1,0 +1,82 @@
+import { resolveTriggerAction } from '../triggers';
+
+const el = (html: string): Element => {
+  const container = document.createElement('div');
+  container.innerHTML = html;
+  return container.firstElementChild!;
+};
+
+suite('resolveTriggerAction', () => {
+  test('data-opencx-open → open', () => {
+    expect(resolveTriggerAction(el('<a data-opencx-open>Chat</a>'))).toEqual({
+      kind: 'open',
+    });
+  });
+
+  test('data-opencx-prefill → prefill with its value', () => {
+    expect(
+      resolveTriggerAction(
+        el('<a data-opencx-prefill="How do I withdraw?">x</a>'),
+      ),
+    ).toEqual({ kind: 'prefill', value: 'How do I withdraw?' });
+  });
+
+  test('data-opencx-ask → ask with its value', () => {
+    expect(
+      resolveTriggerAction(
+        el('<a data-opencx-ask="What are your fees?">x</a>'),
+      ),
+    ).toEqual({ kind: 'ask', value: 'What are your fees?' });
+  });
+
+  test('data-opencx-answer → answer with its value', () => {
+    expect(
+      resolveTriggerAction(
+        el('<a data-opencx-answer="Onboarding ~2 min">x</a>'),
+      ),
+    ).toEqual({ kind: 'answer', value: 'Onboarding ~2 min' });
+  });
+
+  test('an empty attribute value is preserved (not treated as missing)', () => {
+    expect(resolveTriggerAction(el('<a data-opencx-prefill="">x</a>'))).toEqual(
+      {
+        kind: 'prefill',
+        value: '',
+      },
+    );
+  });
+
+  test('resolves from the nearest trigger ancestor when a child is clicked', () => {
+    const trigger = el('<a data-opencx-prefill="Q"><span>label</span></a>');
+    const child = trigger.querySelector('span');
+    expect(resolveTriggerAction(child)).toEqual({
+      kind: 'prefill',
+      value: 'Q',
+    });
+  });
+
+  test('precedence: prefill wins over open on the same element', () => {
+    expect(
+      resolveTriggerAction(
+        el('<a data-opencx-open data-opencx-prefill="Q">x</a>'),
+      ),
+    ).toEqual({ kind: 'prefill', value: 'Q' });
+  });
+
+  test('precedence: ask wins over answer', () => {
+    expect(
+      resolveTriggerAction(
+        el('<a data-opencx-ask="A" data-opencx-answer="B">x</a>'),
+      ),
+    ).toEqual({ kind: 'ask', value: 'A' });
+  });
+
+  test('a non-trigger element → null', () => {
+    expect(resolveTriggerAction(el('<a href="#">plain</a>'))).toBeNull();
+  });
+
+  test('a non-Element target → null', () => {
+    expect(resolveTriggerAction(null)).toBeNull();
+    expect(resolveTriggerAction(document.createTextNode('hi'))).toBeNull();
+  });
+});

--- a/packages/embed/src/__tests__/triggers.spec.ts
+++ b/packages/embed/src/__tests__/triggers.spec.ts
@@ -7,47 +7,63 @@ const el = (html: string): Element => {
 };
 
 suite('resolveTriggerAction', () => {
-  test('data-opencx-open → open', () => {
-    expect(resolveTriggerAction(el('<a data-opencx-open>Chat</a>'))).toEqual({
+  test('opencx-open → open', () => {
+    expect(resolveTriggerAction(el('<a opencx-open>Chat</a>'))).toEqual({
       kind: 'open',
     });
   });
 
-  test('data-opencx-prefill → prefill with its value', () => {
+  test('opencx-prefill → prefill with its value', () => {
     expect(
-      resolveTriggerAction(
-        el('<a data-opencx-prefill="How do I withdraw?">x</a>'),
-      ),
+      resolveTriggerAction(el('<a opencx-prefill="How do I withdraw?">x</a>')),
     ).toEqual({ kind: 'prefill', value: 'How do I withdraw?' });
   });
 
-  test('data-opencx-ask → ask with its value', () => {
+  test('opencx-ask → ask with its value', () => {
     expect(
-      resolveTriggerAction(
-        el('<a data-opencx-ask="What are your fees?">x</a>'),
-      ),
+      resolveTriggerAction(el('<a opencx-ask="What are your fees?">x</a>')),
     ).toEqual({ kind: 'ask', value: 'What are your fees?' });
   });
 
-  test('data-opencx-answer → answer with its value', () => {
+  test('opencx-answer → answer with its value', () => {
     expect(
-      resolveTriggerAction(
-        el('<a data-opencx-answer="Onboarding ~2 min">x</a>'),
-      ),
+      resolveTriggerAction(el('<a opencx-answer="Onboarding ~2 min">x</a>')),
     ).toEqual({ kind: 'answer', value: 'Onboarding ~2 min' });
   });
 
+  test('the data-opencx-* form is still accepted for every action', () => {
+    expect(resolveTriggerAction(el('<a data-opencx-open>Chat</a>'))).toEqual({
+      kind: 'open',
+    });
+    expect(
+      resolveTriggerAction(el('<a data-opencx-prefill="Q">x</a>')),
+    ).toEqual({ kind: 'prefill', value: 'Q' });
+    expect(resolveTriggerAction(el('<a data-opencx-ask="Q">x</a>'))).toEqual({
+      kind: 'ask',
+      value: 'Q',
+    });
+    expect(
+      resolveTriggerAction(el('<a data-opencx-answer="A">x</a>')),
+    ).toEqual({ kind: 'answer', value: 'A' });
+  });
+
+  test('the bare form wins over the data- form on the same element', () => {
+    expect(
+      resolveTriggerAction(
+        el('<a opencx-prefill="bare" data-opencx-prefill="data">x</a>'),
+      ),
+    ).toEqual({ kind: 'prefill', value: 'bare' });
+  });
+
   test('an empty attribute value is preserved (not treated as missing)', () => {
-    expect(resolveTriggerAction(el('<a data-opencx-prefill="">x</a>'))).toEqual(
-      {
-        kind: 'prefill',
-        value: '',
-      },
-    );
+    expect(resolveTriggerAction(el('<a opencx-prefill="">x</a>'))).toEqual({
+      kind: 'prefill',
+      value: '',
+    });
   });
 
   test('resolves from the nearest trigger ancestor when a child is clicked', () => {
-    const trigger = el('<a data-opencx-prefill="Q"><span>label</span></a>');
+    const trigger = el('<a opencx-prefill="Q"><span>label</span></a>');
     const child = trigger.querySelector('span');
     expect(resolveTriggerAction(child)).toEqual({
       kind: 'prefill',
@@ -57,17 +73,19 @@ suite('resolveTriggerAction', () => {
 
   test('precedence: prefill wins over open on the same element', () => {
     expect(
-      resolveTriggerAction(
-        el('<a data-opencx-open data-opencx-prefill="Q">x</a>'),
-      ),
+      resolveTriggerAction(el('<a opencx-open opencx-prefill="Q">x</a>')),
+    ).toEqual({ kind: 'prefill', value: 'Q' });
+  });
+
+  test('precedence: prefill wins over open across forms (data-open + bare prefill)', () => {
+    expect(
+      resolveTriggerAction(el('<a data-opencx-open opencx-prefill="Q">x</a>')),
     ).toEqual({ kind: 'prefill', value: 'Q' });
   });
 
   test('precedence: ask wins over answer', () => {
     expect(
-      resolveTriggerAction(
-        el('<a data-opencx-ask="A" data-opencx-answer="B">x</a>'),
-      ),
+      resolveTriggerAction(el('<a opencx-ask="A" opencx-answer="B">x</a>')),
     ).toEqual({ kind: 'ask', value: 'A' });
   });
 

--- a/packages/embed/src/index.tsx
+++ b/packages/embed/src/index.tsx
@@ -1,24 +1,106 @@
 import type { WidgetConfig } from '@opencx/widget-core';
-import { Widget } from '@opencx/widget-react';
+import { Widget, type WidgetRef } from '@opencx/widget-react';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { version } from '../package.json';
+import { resolveTriggerAction } from './triggers';
 
 const defaultRootId = 'opencx-root';
+
+/**
+ * Host-page controller for driving the widget from your own links/buttons.
+ * Every method opens the widget as needed and is a no-op (with a warning) until
+ * the widget has finished mounting.
+ */
+type OpenCXWidgetController = {
+  /** Open the widget (no-op if already open — no remount). */
+  open: () => void;
+  /** Close the widget. */
+  close: () => void;
+  /** Toggle the widget open/closed. */
+  toggle: () => void;
+  /** Open the widget and pre-fill the composer with `message` WITHOUT sending. */
+  prefill: (message: string) => void;
+  /** Open the widget on a fresh chat and send `message` immediately. */
+  ask: (message: string) => void;
+  /** Open the widget on a fresh chat and show `message` as a canned AI bubble. */
+  presentAnswer: (message: string) => void;
+};
 
 declare global {
   interface Window {
     initOpenScript: typeof initOpenScript;
     openCXWidgetVersion: string;
+    opencxWidget: OpenCXWidgetController;
+  }
+}
+
+const widgetRef = React.createRef<WidgetRef>();
+
+function withWidget<A extends unknown[]>(
+  fn: (ref: WidgetRef, ...args: A) => void,
+): (...args: A) => void {
+  return (...args: A) => {
+    const ref = widgetRef.current;
+    if (!ref) {
+      console.warn(
+        'opencxWidget: the widget is not ready yet — call this after initOpenScript() has mounted.',
+      );
+      return;
+    }
+    fn(ref, ...args);
+  };
+}
+
+const controller: OpenCXWidgetController = {
+  open: withWidget((ref) => ref.open()),
+  close: withWidget((ref) => ref.close()),
+  toggle: withWidget((ref) => ref.toggle()),
+  prefill: withWidget((ref, message: string) => ref.prefill(message)),
+  ask: withWidget((ref, message: string) => void ref.ask(message)),
+  presentAnswer: withWidget((ref, message: string) =>
+    ref.presentAnswer(message),
+  ),
+};
+
+/**
+ * Zero-JS triggers: any element carrying one of these data attributes drives the
+ * widget on click.
+ *   <a data-opencx-open>Chat</a>
+ *   <a data-opencx-prefill="How do I...?">Ask</a>
+ *   <a data-opencx-ask="What are your fees?">Fees</a>
+ *   <a data-opencx-answer="Onboarding takes ~2 minutes...">Onboarding</a>
+ */
+function handleTriggerClick(event: MouseEvent) {
+  const action = resolveTriggerAction(event.target);
+  if (!action) return;
+
+  event.preventDefault();
+
+  switch (action.kind) {
+    case 'prefill':
+      controller.prefill(action.value);
+      break;
+    case 'ask':
+      controller.ask(action.value);
+      break;
+    case 'answer':
+      controller.presentAnswer(action.value);
+      break;
+    case 'open':
+      controller.open();
+      break;
   }
 }
 
 function initOpenScript(options: WidgetConfig) {
-  render(defaultRootId, <Widget options={options} />);
+  render(defaultRootId, <Widget ref={widgetRef} options={options} />);
 }
 
 window.initOpenScript = initOpenScript;
 window.openCXWidgetVersion = version;
+window.opencxWidget = controller;
+document.addEventListener('click', handleTriggerClick);
 
 export function render(rootId: string, component: React.JSX.Element) {
   let rootElement = document.getElementById(rootId);

--- a/packages/embed/src/index.tsx
+++ b/packages/embed/src/index.tsx
@@ -25,6 +25,10 @@ type OpenCXWidgetController = {
   ask: (message: string) => void;
   /** Open the widget on a fresh chat and show `message` as a canned AI bubble. */
   presentAnswer: (message: string) => void;
+  /** Force-show the configured CTA card, bypassing dismissal/URL/delay rules. */
+  showCta: () => void;
+  /** Force-hide the CTA card until `showCta()` or a reload. */
+  hideCta: () => void;
 };
 
 declare global {
@@ -61,6 +65,8 @@ const controller: OpenCXWidgetController = {
   presentAnswer: withWidget((ref, message: string) =>
     ref.presentAnswer(message),
   ),
+  showCta: withWidget((ref) => ref.showCta()),
+  hideCta: withWidget((ref) => ref.hideCta()),
 };
 
 /**

--- a/packages/embed/src/index.tsx
+++ b/packages/embed/src/index.tsx
@@ -64,12 +64,13 @@ const controller: OpenCXWidgetController = {
 };
 
 /**
- * Zero-JS triggers: any element carrying one of these data attributes drives the
+ * Zero-JS triggers: any element carrying one of these attributes drives the
  * widget on click.
- *   <a data-opencx-open>Chat</a>
- *   <a data-opencx-prefill="How do I...?">Ask</a>
- *   <a data-opencx-ask="What are your fees?">Fees</a>
- *   <a data-opencx-answer="Onboarding takes ~2 minutes...">Onboarding</a>
+ *   <a opencx-open>Chat</a>
+ *   <a opencx-prefill="How do I...?">Ask</a>
+ *   <a opencx-ask="What are your fees?">Fees</a>
+ *   <a opencx-answer="Onboarding takes ~2 minutes...">Onboarding</a>
+ * The `data-opencx-*` form is also accepted.
  */
 function handleTriggerClick(event: MouseEvent) {
   const action = resolveTriggerAction(event.target);

--- a/packages/embed/src/triggers.ts
+++ b/packages/embed/src/triggers.ts
@@ -5,11 +5,19 @@ export type TriggerAction =
   | { kind: 'answer'; value: string };
 
 export const TRIGGER_SELECTOR =
+  '[opencx-open],[opencx-prefill],[opencx-ask],[opencx-answer],' +
   '[data-opencx-open],[data-opencx-prefill],[data-opencx-ask],[data-opencx-answer]';
+
+/** Reads `opencx-*`, falling back to the `data-opencx-*` form. */
+function triggerAttribute(el: Element, name: string): string | null {
+  return el.getAttribute(`opencx-${name}`) ?? el.getAttribute(`data-opencx-${name}`);
+}
 
 /**
  * Resolves the OpenCX trigger action for a clicked element (or its nearest
  * trigger ancestor). Returns `null` when the target is not a trigger.
+ * The documented attributes are `opencx-*`; the `data-opencx-*` form is also
+ * accepted for hosts that need HTML-validator-clean markup.
  * Precedence when several attributes are present: prefill > ask > answer > open.
  */
 export function resolveTriggerAction(
@@ -19,13 +27,13 @@ export function resolveTriggerAction(
   const el = target.closest(TRIGGER_SELECTOR);
   if (!el) return null;
 
-  const prefill = el.getAttribute('data-opencx-prefill');
+  const prefill = triggerAttribute(el, 'prefill');
   if (prefill !== null) return { kind: 'prefill', value: prefill };
 
-  const ask = el.getAttribute('data-opencx-ask');
+  const ask = triggerAttribute(el, 'ask');
   if (ask !== null) return { kind: 'ask', value: ask };
 
-  const answer = el.getAttribute('data-opencx-answer');
+  const answer = triggerAttribute(el, 'answer');
   if (answer !== null) return { kind: 'answer', value: answer };
 
   return { kind: 'open' };

--- a/packages/embed/src/triggers.ts
+++ b/packages/embed/src/triggers.ts
@@ -1,0 +1,32 @@
+export type TriggerAction =
+  | { kind: 'open' }
+  | { kind: 'prefill'; value: string }
+  | { kind: 'ask'; value: string }
+  | { kind: 'answer'; value: string };
+
+export const TRIGGER_SELECTOR =
+  '[data-opencx-open],[data-opencx-prefill],[data-opencx-ask],[data-opencx-answer]';
+
+/**
+ * Resolves the OpenCX trigger action for a clicked element (or its nearest
+ * trigger ancestor). Returns `null` when the target is not a trigger.
+ * Precedence when several attributes are present: prefill > ask > answer > open.
+ */
+export function resolveTriggerAction(
+  target: EventTarget | null,
+): TriggerAction | null {
+  if (!(target instanceof Element)) return null;
+  const el = target.closest(TRIGGER_SELECTOR);
+  if (!el) return null;
+
+  const prefill = el.getAttribute('data-opencx-prefill');
+  if (prefill !== null) return { kind: 'prefill', value: prefill };
+
+  const ask = el.getAttribute('data-opencx-ask');
+  if (ask !== null) return { kind: 'ask', value: ask };
+
+  const answer = el.getAttribute('data-opencx-answer');
+  if (answer !== null) return { kind: 'answer', value: answer };
+
+  return { kind: 'open' };
+}

--- a/packages/react-headless/src/hooks/useComposerDraft.ts
+++ b/packages/react-headless/src/hooks/useComposerDraft.ts
@@ -1,0 +1,14 @@
+import { usePrimitiveState } from './usePrimitiveState';
+import { useWidget } from '../WidgetProvider';
+
+/**
+ * The chat composer's draft text, lifted into core state so it can be set
+ * programmatically (e.g. the host-facing `prefill` trigger) as well as by the
+ * input component. `setDraft` updates it without sending.
+ */
+export function useComposerDraft() {
+  const { widgetCtx } = useWidget();
+  const draft = usePrimitiveState(widgetCtx.composerDraft);
+
+  return { draft, setDraft: widgetCtx.setComposerDraft };
+}

--- a/packages/react-headless/src/hooks/useMessages.ts
+++ b/packages/react-headless/src/hooks/useMessages.ts
@@ -5,5 +5,9 @@ export function useMessages() {
   const { widgetCtx } = useWidget();
   const messagesState = usePrimitiveState(widgetCtx.messageCtx.state);
 
-  return { messagesState, sendMessage: widgetCtx.messageCtx.sendMessage };
+  return {
+    messagesState,
+    sendMessage: widgetCtx.messageCtx.sendMessage,
+    injectLocalAgentMessage: widgetCtx.messageCtx.injectLocalAgentMessage,
+  };
 }

--- a/packages/react-headless/src/index.ts
+++ b/packages/react-headless/src/index.ts
@@ -10,6 +10,7 @@ export { useContact } from './hooks/useContact';
 export { useDocumentDir } from './hooks/useDocumentDir';
 export { useIsAwaitingBotReply } from './hooks/useIsAwaitingBotReply';
 export { useMessages } from './hooks/useMessages';
+export { useComposerDraft } from './hooks/useComposerDraft';
 export { usePrimitiveState } from './hooks/usePrimitiveState';
 export { useSessions } from './hooks/useSessions';
 export { useWidgetRouter } from './hooks/useWidgetRouter';

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -60,10 +60,15 @@
     "@opencx/eslint-config": "workspace:*",
     "@opencx/tsconfig": "workspace:*",
     "@tailwindcss/typography": "^0.5.15",
+    "@testing-library/react": "^16.3.2",
     "@types/tinycolor2": "^1.4.6",
+    "@vitejs/plugin-react-swc": "^4.0.0",
+    "jsdom": "^25.0.1",
     "postcss": "^8.4.41",
     "tailwindcss": "^3.4.6",
     "tailwindcss-animate": "^1.0.7",
-    "vite-plugin-qrcode": "^0.3.0"
+    "vite-plugin-qrcode": "^0.3.0",
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/react/src/CtaCard.tsx
+++ b/packages/react/src/CtaCard.tsx
@@ -1,0 +1,140 @@
+import { ArrowUpIcon, XIcon } from 'lucide-react';
+import React from 'react';
+import type { CtaButton, CtaConfig } from '@opencx/widget-core';
+import { cn } from './components/lib/utils/cn';
+import { dc } from './utils/data-component';
+
+export type CtaCardProps = {
+  cta: CtaConfig;
+  onButtonClick: (button: CtaButton, index: number) => void;
+  onComposerSubmit: (text: string) => void;
+  onDismiss: () => void;
+};
+
+/**
+ * Purely presentational CTA/teaser card. All visibility rules, persistence,
+ * and widget wiring live in `CtaContainer` — this component only renders the
+ * configured content and reports interactions upward.
+ */
+export function CtaCard({
+  cta,
+  onButtonClick,
+  onComposerSubmit,
+  onDismiss,
+}: CtaCardProps) {
+  const [draft, setDraft] = React.useState('');
+
+  return (
+    <div
+      {...dc('cta/root')}
+      className={cn(
+        'font-sans relative flex flex-col gap-3',
+        'bg-background text-foreground',
+        'rounded-2xl p-4 shadow-xl',
+      )}
+    >
+      <button
+        {...dc('cta/dismiss_btn')}
+        type="button"
+        aria-label="Dismiss"
+        onClick={onDismiss}
+        className={cn(
+          'absolute end-2 top-2 z-10 rounded-full p-1 cursor-pointer',
+          'text-muted-foreground hover:bg-secondary',
+        )}
+      >
+        <XIcon className="size-4" />
+      </button>
+
+      {cta.imageUrl && (
+        <img
+          {...dc('cta/image')}
+          src={cta.imageUrl}
+          alt=""
+          className="-mx-4 -mt-4 w-[calc(100%+2rem)] rounded-t-2xl object-cover"
+        />
+      )}
+
+      <p {...dc('cta/title')} className="m-0 pe-6 text-base font-semibold">
+        {cta.title}
+      </p>
+
+      {cta.body && (
+        <p {...dc('cta/body')} className="m-0 text-sm text-muted-foreground">
+          {cta.body}
+        </p>
+      )}
+
+      {cta.avatarUrls && cta.avatarUrls.length > 0 && (
+        <div {...dc('cta/avatars')} className="flex -space-x-2">
+          {cta.avatarUrls.map((url, i) => (
+            <img
+              key={i}
+              src={url}
+              alt=""
+              className="size-7 rounded-full border-2 border-background object-cover"
+            />
+          ))}
+        </div>
+      )}
+
+      {cta.buttons && cta.buttons.length > 0 && (
+        <div className="flex flex-col gap-2">
+          {cta.buttons.map((button, index) => (
+            <button
+              key={index}
+              {...dc('cta/btn')}
+              type="button"
+              data-variant={button.variant ?? 'primary'}
+              onClick={() => onButtonClick(button, index)}
+              className={cn(
+                'rounded-xl px-4 py-2.5 text-sm font-medium cursor-pointer transition-colors',
+                (button.variant ?? 'primary') === 'primary'
+                  ? 'bg-primary text-primary-foreground hover:opacity-90'
+                  : 'bg-secondary text-secondary-foreground hover:opacity-90',
+              )}
+            >
+              {button.text}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {cta.composer && (
+        <form
+          {...dc('cta/composer/root')}
+          className="flex items-center gap-2"
+          onSubmit={(event) => {
+            event.preventDefault();
+            const text = draft.trim();
+            if (!text) return;
+            onComposerSubmit(text);
+            setDraft('');
+          }}
+        >
+          <input
+            {...dc('cta/composer/input')}
+            value={draft}
+            onChange={(event) => setDraft(event.target.value)}
+            placeholder={cta.composer.placeholder ?? 'Write a message…'}
+            className={cn(
+              'min-w-0 flex-1 rounded-full border border-input bg-transparent',
+              'px-3.5 py-2 text-sm outline-none focus:border-primary',
+            )}
+          />
+          <button
+            {...dc('cta/composer/send_btn')}
+            type="submit"
+            aria-label="Send"
+            className={cn(
+              'flex size-9 shrink-0 items-center justify-center rounded-full cursor-pointer',
+              'bg-primary text-primary-foreground hover:opacity-90',
+            )}
+          >
+            <ArrowUpIcon className="size-4" />
+          </button>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/packages/react/src/CtaCard.tsx
+++ b/packages/react/src/CtaCard.tsx
@@ -28,9 +28,10 @@ export function CtaCard({
     <div
       {...dc('cta/root')}
       className={cn(
-        'font-sans relative flex flex-col gap-3',
+        'font-sans relative flex flex-col',
         'bg-background text-foreground',
-        'rounded-2xl p-4 shadow-xl',
+        'rounded-2xl border border-black/5 p-4',
+        'shadow-[0_12px_40px_-8px_rgba(0,0,0,0.18)]',
       )}
     >
       <button
@@ -39,8 +40,11 @@ export function CtaCard({
         aria-label="Dismiss"
         onClick={onDismiss}
         className={cn(
-          'absolute end-2 top-2 z-10 rounded-full p-1 cursor-pointer',
-          'text-muted-foreground hover:bg-secondary',
+          'absolute end-2 top-2 z-10 rounded-full p-1.5 cursor-pointer transition-colors',
+          // Over an image header the glyph needs its own scrim to stay visible.
+          cta.imageUrl
+            ? 'bg-black/25 text-white backdrop-blur-[2px] hover:bg-black/40'
+            : 'text-muted-foreground hover:bg-secondary',
         )}
       >
         <XIcon className="size-4" />
@@ -51,35 +55,41 @@ export function CtaCard({
           {...dc('cta/image')}
           src={cta.imageUrl}
           alt=""
-          className="-mx-4 -mt-4 w-[calc(100%+2rem)] rounded-t-2xl object-cover"
+          className="-mx-4 -mt-4 mb-3.5 max-h-44 w-[calc(100%+2rem)] rounded-t-2xl object-cover"
         />
       )}
 
-      <p {...dc('cta/title')} className="m-0 pe-6 text-base font-semibold">
+      <p
+        {...dc('cta/title')}
+        className="m-0 pe-6 text-[17px] font-bold leading-snug tracking-[-0.01em]"
+      >
         {cta.title}
       </p>
 
       {cta.body && (
-        <p {...dc('cta/body')} className="m-0 text-sm text-muted-foreground">
+        <p
+          {...dc('cta/body')}
+          className="m-0 mt-1 text-[13.5px] leading-normal text-muted-foreground"
+        >
           {cta.body}
         </p>
       )}
 
       {cta.avatarUrls && cta.avatarUrls.length > 0 && (
-        <div {...dc('cta/avatars')} className="flex -space-x-2">
+        <div {...dc('cta/avatars')} className="mt-2.5 flex -space-x-2.5">
           {cta.avatarUrls.map((url, i) => (
             <img
               key={i}
               src={url}
               alt=""
-              className="size-7 rounded-full border-2 border-background object-cover"
+              className="size-8 rounded-full border-2 border-background object-cover"
             />
           ))}
         </div>
       )}
 
       {cta.buttons && cta.buttons.length > 0 && (
-        <div className="flex flex-col gap-2">
+        <div className="mt-3.5 flex flex-col gap-2">
           {cta.buttons.map((button, index) => (
             <button
               key={index}
@@ -88,10 +98,10 @@ export function CtaCard({
               data-variant={button.variant ?? 'primary'}
               onClick={() => onButtonClick(button, index)}
               className={cn(
-                'rounded-xl px-4 py-2.5 text-sm font-medium cursor-pointer transition-colors',
+                'rounded-[14px] px-4 py-2.5 text-sm cursor-pointer transition-colors',
                 (button.variant ?? 'primary') === 'primary'
-                  ? 'bg-primary text-primary-foreground hover:opacity-90'
-                  : 'bg-secondary text-secondary-foreground hover:opacity-90',
+                  ? 'bg-primary font-semibold text-primary-foreground hover:opacity-90'
+                  : 'bg-secondary font-medium text-secondary-foreground hover:opacity-90',
               )}
             >
               {button.text}
@@ -103,7 +113,7 @@ export function CtaCard({
       {cta.composer && (
         <form
           {...dc('cta/composer/root')}
-          className="flex items-center gap-2"
+          className="mt-3 flex items-center gap-2"
           onSubmit={(event) => {
             event.preventDefault();
             const text = draft.trim();
@@ -118,8 +128,8 @@ export function CtaCard({
             onChange={(event) => setDraft(event.target.value)}
             placeholder={cta.composer.placeholder ?? 'Write a message…'}
             className={cn(
-              'min-w-0 flex-1 rounded-full border border-input bg-transparent',
-              'px-3.5 py-2 text-sm outline-none focus:border-primary',
+              'min-w-0 flex-1 rounded-full border border-transparent bg-secondary',
+              'px-3.5 py-2 text-sm outline-none transition-colors focus:border-primary',
             )}
           />
           <button

--- a/packages/react/src/CtaCard.tsx
+++ b/packages/react/src/CtaCard.tsx
@@ -55,7 +55,13 @@ export function CtaCard({
           {...dc('cta/image')}
           src={cta.imageUrl}
           alt=""
-          className="-mx-4 -mt-4 mb-3.5 max-h-44 w-[calc(100%+2rem)] rounded-t-2xl object-cover"
+          // Full bleed across the card's p-4. Two traps here: the calc()
+          // underscores are required (Tailwind renders them as spaces; calc
+          // without spaces around '+' is invalid CSS and gets dropped), and
+          // max-w-none is required to defeat preflight's `img { max-width:
+          // 100% }` — either one alone leaves the image shifted left with a
+          // gap at the dismiss button.
+          className="-mx-4 -mt-4 mb-3.5 max-h-44 w-[calc(100%_+_2rem)] max-w-none rounded-t-2xl object-cover"
         />
       )}
 

--- a/packages/react/src/CtaContainer.tsx
+++ b/packages/react/src/CtaContainer.tsx
@@ -4,6 +4,7 @@ import styles from '../index.css?inline.css';
 import {
   ctaUrlMatches,
   isCtaDismissed,
+  isExhaustive,
   parseCtaDismissalRecord,
   resolveCtaVisible,
   type CtaButton,
@@ -42,6 +43,14 @@ function dismissalStorageKey(token: string) {
   return `opencx:cta:dismissed:${token}`;
 }
 
+function readDismissalRecord(token: string): string | null {
+  try {
+    return localStorage.getItem(dismissalStorageKey(token));
+  } catch {
+    return null;
+  }
+}
+
 export function CtaContainer() {
   const config = useConfig();
   const { widgetCtx } = useWidget();
@@ -58,9 +67,10 @@ export function CtaContainer() {
 
   const [dismissed, setDismissed] = React.useState(() =>
     isCtaDismissed(
-      parseCtaDismissalRecord(
-        localStorage.getItem(dismissalStorageKey(config.token)),
-      ),
+      // Guarded: this initializer runs during render for every non-inline
+      // widget (hooks precede the no-cta early return), and localStorage
+      // access throws synchronously when the host blocks site data.
+      parseCtaDismissalRecord(readDismissalRecord(config.token)),
       cta?.dismissForDays,
       Date.now(),
     ),
@@ -116,10 +126,15 @@ export function CtaContainer() {
   if (!cta || !visible) return null;
 
   const dismiss = () => {
-    localStorage.setItem(
-      dismissalStorageKey(config.token),
-      JSON.stringify({ dismissedAt: Date.now() }),
-    );
+    try {
+      localStorage.setItem(
+        dismissalStorageKey(config.token),
+        JSON.stringify({ dismissedAt: Date.now() }),
+      );
+    } catch (e) {
+      // Blocked/full storage must not keep the card on screen.
+      console.warn('CTA: could not persist dismissal', e);
+    }
     setDismissed(true);
     if (override === 'show') widgetCtx.setCtaOverride(null);
     config.hooks?.onCtaDismissed?.();
@@ -158,6 +173,8 @@ export function CtaContainer() {
           button.openInNewTab === false ? '_self' : '_blank',
         );
         break;
+      default:
+        isExhaustive(button);
     }
   };
 

--- a/packages/react/src/CtaContainer.tsx
+++ b/packages/react/src/CtaContainer.tsx
@@ -97,16 +97,21 @@ export function CtaContainer() {
 
   // The card's children render into the iframe via a portal, so this observer
   // runs in the host context and can size the iframe element to its content.
+  // Callback ref (not an effect): @uiw/react-iframe re-portals the children
+  // once the iframe document loads, so we must observe whichever node is
+  // currently mounted — an effect keyed on `visible` would keep watching the
+  // first, detached node and the iframe would stay at its 150px default.
   const [height, setHeight] = React.useState(0);
-  const wrapperRef = React.useRef<HTMLDivElement>(null);
-  React.useEffect(() => {
-    const el = wrapperRef.current;
+  const resizeObserverRef = React.useRef<ResizeObserver | null>(null);
+  const wrapperRef = React.useCallback((el: HTMLDivElement | null) => {
+    resizeObserverRef.current?.disconnect();
+    resizeObserverRef.current = null;
     if (!el) return;
     const observer = new ResizeObserver(() => setHeight(el.offsetHeight));
     observer.observe(el);
     setHeight(el.offsetHeight);
-    return () => observer.disconnect();
-  }, [visible]);
+    resizeObserverRef.current = observer;
+  }, []);
 
   if (!cta || !visible) return null;
 

--- a/packages/react/src/CtaContainer.tsx
+++ b/packages/react/src/CtaContainer.tsx
@@ -1,4 +1,5 @@
 import IFrame from '@uiw/react-iframe';
+import { motion, useReducedMotion } from 'framer-motion';
 import React from 'react';
 import styles from '../index.css?inline.css';
 import {
@@ -19,7 +20,73 @@ import {
   useWidgetTrigger,
 } from '@opencx/widget-react-headless';
 import { CtaCard } from './CtaCard';
+import { dc } from './utils/data-component';
 import { useTheme } from './hooks/useTheme';
+
+/**
+ * Gooey transition (Aceternity gooey-input / Chris Coyier goo): the filter
+ * lives on a BLOB layer only — blur + a high-contrast alpha matrix makes
+ * nearby shapes visually merge like liquid — while the real card content sits
+ * unfiltered above so text stays crisp. The blob springs toward the launcher
+ * corner and merges with a small droplet parked there; springs are
+ * interruptible, so rapid open/close retargets mid-flight instead of
+ * glitching.
+ */
+const GOO_SVG = (
+  <svg width="0" height="0" aria-hidden="true" style={{ position: 'absolute' }}>
+    <defs>
+      <filter id="opencx-cta-goo">
+        <feGaussianBlur in="SourceGraphic" stdDeviation="5" result="blur" />
+        <feColorMatrix
+          in="blur"
+          values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 19 -9"
+        />
+      </filter>
+    </defs>
+  </svg>
+);
+
+const SPRING = { type: 'spring', stiffness: 380, damping: 32 } as const;
+
+/**
+ * Exported for tests. `reduced` (prefers-reduced-motion) collapses every
+ * transition to an instant swap while keeping one render path.
+ */
+export function makeCtaMotionVariants(reduced: boolean) {
+  const instant = { duration: 0 } as const;
+  return {
+    blob: {
+      shown: { scale: 1, x: 0, y: 0, transition: reduced ? instant : SPRING },
+      hidden: {
+        scale: 0.04,
+        x: 24,
+        y: 24,
+        transition: reduced ? instant : SPRING,
+      },
+    },
+    droplet: {
+      shown: { scale: 0, transition: reduced ? instant : SPRING },
+      hidden: {
+        scale: reduced ? 0 : [1.4, 0],
+        transition: reduced ? instant : { duration: 0.34, delay: 0.1 },
+      },
+    },
+    content: {
+      // Content re-enters once the blob has mostly re-formed.
+      shown: {
+        opacity: 1,
+        scale: 1,
+        transition: reduced ? instant : { duration: 0.18, delay: 0.16 },
+      },
+      // Content bows out fast so the goo never blurs live text.
+      hidden: {
+        opacity: 0,
+        scale: 0.97,
+        transition: reduced ? instant : { duration: 0.12 },
+      },
+    },
+  } as const;
+}
 
 const initialContent = `<!DOCTYPE html>
 <html>
@@ -63,6 +130,11 @@ export function CtaContainer() {
   const { sendMessage } = useMessages();
   const { theme, cssVars } = useTheme();
   const override = usePrimitiveState(widgetCtx.ctaOverride);
+  const reducedMotion = useReducedMotion();
+  const variants = React.useMemo(
+    () => makeCtaMotionVariants(!!reducedMotion),
+    [reducedMotion],
+  );
   const cta = config.cta;
 
   const [dismissed, setDismissed] = React.useState(() =>
@@ -130,10 +202,18 @@ export function CtaContainer() {
     resizeObserverRef.current = observer;
   }, []);
 
+  // Once the exit animation settles, the (invisible) iframe must stop
+  // hit-testing and disappear from the a11y tree.
+  const [exitDone, setExitDone] = React.useState(!visible);
+  React.useEffect(() => {
+    if (visible) setExitDone(false);
+  }, [visible]);
+  const fullyHidden = !visible && exitDone;
+
   // Stay MOUNTED while merely hidden (widget open, rules pending): the card's
   // local state — e.g. a half-typed composer draft — must survive open/close
-  // round-trips ("picks up where it left off"), and a persistent element is
-  // what the future transform animation will interpolate between.
+  // round-trips ("picks up where it left off"), and the persistent element is
+  // what the goo animation interpolates between.
   if (!cta) return null;
 
   const dismiss = () => {
@@ -199,7 +279,10 @@ export function CtaContainer() {
       initialContent={initialContent}
       title="OpenCX Chat CTA"
       style={{
-        display: visible ? undefined : 'none',
+        // Kept displayed while animating; fully hidden only once the exit
+        // settles (so springs can play), and never hit-testable while hidden.
+        visibility: fullyHidden ? 'hidden' : undefined,
+        pointerEvents: visible ? undefined : 'none',
         position: 'fixed',
         zIndex: theme.widgetTrigger.zIndex,
         right: theme.widgetTrigger.offset.right,
@@ -219,13 +302,63 @@ export function CtaContainer() {
       }}
     >
       {config.cssOverrides && <style>{config.cssOverrides}</style>}
-      <div ref={wrapperRef} style={{ ...cssVars }}>
-        <CtaCard
-          cta={cta}
-          onButtonClick={handleButtonClick}
-          onComposerSubmit={handleComposerSubmit}
-          onDismiss={dismiss}
-        />
+      <div ref={wrapperRef} style={{ ...cssVars, position: 'relative' }}>
+        {GOO_SVG}
+        {/* Goo layer: filter applies ONLY here so live text never blurs. */}
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            filter: 'url(#opencx-cta-goo)',
+            pointerEvents: 'none',
+          }}
+        >
+          <motion.div
+            {...dc('cta/goo_blob')}
+            className="bg-background"
+            variants={variants.blob}
+            animate={visible ? 'shown' : 'hidden'}
+            initial={false}
+            onAnimationComplete={(definition) => {
+              if (definition === 'hidden') setExitDone(true);
+            }}
+            style={{
+              position: 'absolute',
+              inset: 0,
+              borderRadius: 16,
+              transformOrigin: '100% 100%',
+            }}
+          />
+          <motion.div
+            {...dc('cta/goo_blob')}
+            className="bg-background"
+            variants={variants.droplet}
+            animate={visible ? 'shown' : 'hidden'}
+            initial={false}
+            style={{
+              position: 'absolute',
+              right: 6,
+              bottom: 6,
+              width: 26,
+              height: 26,
+              borderRadius: '50%',
+            }}
+          />
+        </div>
+        {/* Content layer: the real card, unfiltered and crisp. */}
+        <motion.div
+          variants={variants.content}
+          animate={visible ? 'shown' : 'hidden'}
+          initial={false}
+          style={{ position: 'relative', transformOrigin: '100% 100%' }}
+        >
+          <CtaCard
+            cta={cta}
+            onButtonClick={handleButtonClick}
+            onComposerSubmit={handleComposerSubmit}
+            onDismiss={dismiss}
+          />
+        </motion.div>
       </div>
     </IFrame>
   );

--- a/packages/react/src/CtaContainer.tsx
+++ b/packages/react/src/CtaContainer.tsx
@@ -1,0 +1,193 @@
+import IFrame from '@uiw/react-iframe';
+import React from 'react';
+import styles from '../index.css?inline.css';
+import {
+  ctaUrlMatches,
+  isCtaDismissed,
+  parseCtaDismissalRecord,
+  resolveCtaVisible,
+  type CtaButton,
+} from '@opencx/widget-core';
+import {
+  useConfig,
+  useContact,
+  useMessages,
+  usePrimitiveState,
+  useWidget,
+  useWidgetRouter,
+  useWidgetTrigger,
+} from '@opencx/widget-react-headless';
+import { CtaCard } from './CtaCard';
+import { useTheme } from './hooks/useTheme';
+
+const initialContent = `<!DOCTYPE html>
+<html>
+<head>
+<style>
+${styles}
+html, body {
+    height: 100%;
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    font-size: 16px;
+}
+</style>
+</head>
+<body>
+</body>
+</html>`;
+
+function dismissalStorageKey(token: string) {
+  return `opencx:cta:dismissed:${token}`;
+}
+
+export function CtaContainer() {
+  const config = useConfig();
+  const { widgetCtx } = useWidget();
+  const { contactState } = useContact();
+  const { isOpen, setIsOpen } = useWidgetTrigger();
+  const {
+    toChatScreen,
+    routerState: { screen },
+  } = useWidgetRouter();
+  const { sendMessage } = useMessages();
+  const { theme, cssVars } = useTheme();
+  const override = usePrimitiveState(widgetCtx.ctaOverride);
+  const cta = config.cta;
+
+  const [dismissed, setDismissed] = React.useState(() =>
+    isCtaDismissed(
+      parseCtaDismissalRecord(
+        localStorage.getItem(dismissalStorageKey(config.token)),
+      ),
+      cta?.dismissForDays,
+      Date.now(),
+    ),
+  );
+
+  const [delayElapsed, setDelayElapsed] = React.useState(
+    !cta?.showAfterSeconds,
+  );
+  React.useEffect(() => {
+    if (!cta?.showAfterSeconds) return;
+    const timer = setTimeout(
+      () => setDelayElapsed(true),
+      cta.showAfterSeconds * 1000,
+    );
+    return () => clearTimeout(timer);
+  }, [cta?.showAfterSeconds]);
+
+  const visible = resolveCtaVisible({
+    hasCta: !!cta,
+    isWidgetOpen: isOpen,
+    override,
+    dismissed,
+    urlMatches: ctaUrlMatches(cta?.urlMatch, window.location.href),
+    delayElapsed,
+  });
+
+  const displayedRef = React.useRef(false);
+  React.useEffect(() => {
+    if (visible && !displayedRef.current) {
+      displayedRef.current = true;
+      config.hooks?.onCtaDisplayed?.();
+    }
+  }, [visible, config.hooks]);
+
+  // The card's children render into the iframe via a portal, so this observer
+  // runs in the host context and can size the iframe element to its content.
+  const [height, setHeight] = React.useState(0);
+  const wrapperRef = React.useRef<HTMLDivElement>(null);
+  React.useEffect(() => {
+    const el = wrapperRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver(() => setHeight(el.offsetHeight));
+    observer.observe(el);
+    setHeight(el.offsetHeight);
+    return () => observer.disconnect();
+  }, [visible]);
+
+  if (!cta || !visible) return null;
+
+  const dismiss = () => {
+    localStorage.setItem(
+      dismissalStorageKey(config.token),
+      JSON.stringify({ dismissedAt: Date.now() }),
+    );
+    setDismissed(true);
+    if (override === 'show') widgetCtx.setCtaOverride(null);
+    config.hooks?.onCtaDismissed?.();
+  };
+
+  // Inlined equivalent of WidgetImperativeHandler's newChat({ message }).
+  const ask = (message: string) => {
+    if (!contactState.contact?.token) {
+      console.warn('CTA: cannot start a chat — contact not yet initialized.');
+      return;
+    }
+    setIsOpen(true);
+    if (screen === 'chat') widgetCtx.resetChat();
+    toChatScreen();
+    sendMessage({ content: message });
+  };
+
+  const handleButtonClick = (button: CtaButton, index: number) => {
+    config.hooks?.onCtaClicked?.({ action: button.action, index });
+    switch (button.action) {
+      case 'open-chat':
+        setIsOpen(true);
+        break;
+      case 'prefill':
+        // Inlined equivalent of WidgetImperativeHandler's prefill().
+        setIsOpen(true);
+        if (screen !== 'chat') toChatScreen();
+        widgetCtx.setComposerDraft(button.message);
+        break;
+      case 'ask':
+        ask(button.message);
+        break;
+      case 'url':
+        window.open(
+          button.url,
+          button.openInNewTab === false ? '_self' : '_blank',
+        );
+        break;
+    }
+  };
+
+  const handleComposerSubmit = (text: string) => {
+    config.hooks?.onCtaClicked?.({ action: 'composer' });
+    ask(text);
+  };
+
+  return (
+    <IFrame
+      initialContent={initialContent}
+      title="OpenCX Chat CTA"
+      style={{
+        position: 'fixed',
+        zIndex: theme.widgetTrigger.zIndex,
+        right: theme.widgetTrigger.offset.right,
+        left: theme.widgetTrigger.offset.left,
+        bottom: `calc(${theme.widgetTrigger.offset.bottom}px + ${theme.widgetTrigger.size.button}px + 16px)`,
+        width: 'min(360px, calc(100vw - 32px))',
+        height: height || undefined,
+        fontSize: '16px',
+        boxSizing: 'border-box',
+        borderWidth: '0px',
+        borderRadius: '16px',
+      }}
+    >
+      {config.cssOverrides && <style>{config.cssOverrides}</style>}
+      <div ref={wrapperRef} style={{ ...cssVars }}>
+        <CtaCard
+          cta={cta}
+          onButtonClick={handleButtonClick}
+          onComposerSubmit={handleComposerSubmit}
+          onDismiss={dismiss}
+        />
+      </div>
+    </IFrame>
+  );
+}

--- a/packages/react/src/CtaContainer.tsx
+++ b/packages/react/src/CtaContainer.tsx
@@ -97,6 +97,13 @@ export function CtaContainer() {
     delayElapsed,
   });
 
+  // Publish the resolved visibility so the launcher can consume it
+  // (`cta.mode: 'transform'` swaps the bubble for the card).
+  React.useEffect(() => {
+    widgetCtx.setCtaVisible(visible);
+    return () => widgetCtx.setCtaVisible(false);
+  }, [widgetCtx, visible]);
+
   const displayedRef = React.useRef(false);
   React.useEffect(() => {
     if (visible && !displayedRef.current) {
@@ -123,7 +130,11 @@ export function CtaContainer() {
     resizeObserverRef.current = observer;
   }, []);
 
-  if (!cta || !visible) return null;
+  // Stay MOUNTED while merely hidden (widget open, rules pending): the card's
+  // local state — e.g. a half-typed composer draft — must survive open/close
+  // round-trips ("picks up where it left off"), and a persistent element is
+  // what the future transform animation will interpolate between.
+  if (!cta) return null;
 
   const dismiss = () => {
     try {
@@ -188,11 +199,17 @@ export function CtaContainer() {
       initialContent={initialContent}
       title="OpenCX Chat CTA"
       style={{
+        display: visible ? undefined : 'none',
         position: 'fixed',
         zIndex: theme.widgetTrigger.zIndex,
         right: theme.widgetTrigger.offset.right,
         left: theme.widgetTrigger.offset.left,
-        bottom: `calc(${theme.widgetTrigger.offset.bottom}px + ${theme.widgetTrigger.size.button}px + 16px)`,
+        // In transform mode the card IS the launcher, so it takes the
+        // launcher's spot; in coexist mode it floats above the bubble.
+        bottom:
+          cta.mode === 'transform'
+            ? theme.widgetTrigger.offset.bottom
+            : `calc(${theme.widgetTrigger.offset.bottom}px + ${theme.widgetTrigger.size.button}px + 16px)`,
         width: 'min(360px, calc(100vw - 32px))',
         height: height || undefined,
         fontSize: '16px',

--- a/packages/react/src/WidgetImperativeHandler.tsx
+++ b/packages/react/src/WidgetImperativeHandler.tsx
@@ -33,6 +33,13 @@ export type WidgetRef = {
   presentAnswer: (message: string) => void;
   /** Open the widget on a fresh chat, optionally sending an initial `message`. */
   newChat: (options?: { message?: string }) => Promise<void>;
+  /**
+   * Force-show the CTA card (config `cta` required), bypassing its dismissal,
+   * URL, and delay rules. No-op while the widget is open.
+   */
+  showCta: () => void;
+  /** Force-hide the CTA card until `showCta()` or a reload. */
+  hideCta: () => void;
 };
 
 export function WidgetImperativeHandler({
@@ -83,6 +90,8 @@ export function WidgetImperativeHandler({
         injectLocalAgentMessage(message);
       },
       newChat,
+      showCta: () => widgetCtx.setCtaOverride('show'),
+      hideCta: () => widgetCtx.setCtaOverride('hide'),
     };
   }, [
     widgetCtx,

--- a/packages/react/src/WidgetImperativeHandler.tsx
+++ b/packages/react/src/WidgetImperativeHandler.tsx
@@ -8,6 +8,30 @@ import {
 } from '@opencx/widget-react-headless';
 
 export type WidgetRef = {
+  /** Open the widget. No-op if already open (no remount). */
+  open: () => void;
+  /** Close the widget. */
+  close: () => void;
+  /** Toggle the widget between open and closed. */
+  toggle: () => void;
+  /**
+   * Open the widget, go to the chat screen, and pre-fill the composer with
+   * `message` WITHOUT sending it — the visitor presses Enter to send. An
+   * already-open conversation is left intact (only the draft is set).
+   */
+  prefill: (message: string) => void;
+  /**
+   * Open the widget on a fresh chat and send `message` immediately. Alias of
+   * `newChat({ message })`.
+   */
+  ask: (message: string) => Promise<void>;
+  /**
+   * Open the widget on a fresh chat and show `message` as a canned AI bubble.
+   * The bubble is client-only: not persisted and not part of the AI's context.
+   * The visitor can keep chatting normally afterwards.
+   */
+  presentAnswer: (message: string) => void;
+  /** Open the widget on a fresh chat, optionally sending an initial `message`. */
   newChat: (options?: { message?: string }) => Promise<void>;
 };
 
@@ -23,36 +47,53 @@ export function WidgetImperativeHandler({
     toChatScreen,
     routerState: { screen },
   } = useWidgetRouter();
-  const { sendMessage } = useMessages();
+  const { sendMessage, injectLocalAgentMessage } = useMessages();
 
-  React.useImperativeHandle(
-    widgetRef,
-    () => ({
-      newChat: async (options) => {
-        if (!contactState.contact?.token) {
-          console.warn('Cannot start a new chat: contact not yet initialized.');
-          return;
-        }
+  React.useImperativeHandle(widgetRef, () => {
+    const newChat: WidgetRef['newChat'] = async (options) => {
+      if (!contactState.contact?.token) {
+        console.warn('Cannot start a new chat: contact not yet initialized.');
+        return;
+      }
 
-        console.log({ isOpen });
+      if (!isOpen) setIsOpen(true);
+
+      if (screen === 'chat') widgetCtx.resetChat();
+
+      toChatScreen();
+      if (options?.message) sendMessage({ content: options.message });
+    };
+
+    return {
+      open: () => setIsOpen(true),
+      close: () => setIsOpen(false),
+      toggle: () => setIsOpen((prev) => !prev),
+      prefill: (message) => {
         if (!isOpen) setIsOpen(true);
-
-        if (screen === 'chat') widgetCtx.resetChat();
-
-        toChatScreen();
-        if (options?.message) sendMessage({ content: options.message });
+        // Navigating to chat resets the conversation (and clears the draft),
+        // so only navigate when not already chatting, and set the draft AFTER.
+        if (screen !== 'chat') toChatScreen();
+        widgetCtx.setComposerDraft(message);
       },
-    }),
-    [
-      widgetCtx,
-      contactState,
-      setIsOpen,
-      isOpen,
-      screen,
-      toChatScreen,
-      sendMessage,
-    ],
-  );
+      ask: (message) => newChat({ message }),
+      presentAnswer: (message) => {
+        if (!isOpen) setIsOpen(true);
+        // Start a fresh chat (toChatScreen resets), then inject the canned bubble.
+        toChatScreen();
+        injectLocalAgentMessage(message);
+      },
+      newChat,
+    };
+  }, [
+    widgetCtx,
+    contactState,
+    setIsOpen,
+    isOpen,
+    screen,
+    toChatScreen,
+    sendMessage,
+    injectLocalAgentMessage,
+  ]);
 
   return null;
 }

--- a/packages/react/src/WidgetPopoverTrigger.tsx
+++ b/packages/react/src/WidgetPopoverTrigger.tsx
@@ -4,7 +4,12 @@ import { AnimatePresence } from 'framer-motion';
 import { ChevronDownIcon } from 'lucide-react';
 import React from 'react';
 import styles from '../index.css?inline.css';
-import { useConfig, useWidgetTrigger } from '@opencx/widget-react-headless';
+import {
+  useConfig,
+  usePrimitiveState,
+  useWidget,
+  useWidgetTrigger,
+} from '@opencx/widget-react-headless';
 import { MotionDiv } from './components/lib/MotionDiv';
 import { cn } from './components/lib/utils/cn';
 import { Wobble, WOBBLE_MAX_MOVEMENT_PIXELS } from './components/lib/wobble';
@@ -32,7 +37,10 @@ html, body {
 
 function WidgetPopoverTrigger() {
   const { isOpen, setIsOpen } = useWidgetTrigger();
-  const { cssOverrides, assets, customComponents, accessibility } = useConfig();
+  const config = useConfig();
+  const { cssOverrides, assets, customComponents, accessibility } = config;
+  const { widgetCtx } = useWidget();
+  const ctaVisible = usePrimitiveState(widgetCtx.ctaVisible);
   const { theme, cssVars } = useTheme();
 
   const triggerLabel =
@@ -45,6 +53,11 @@ function WidgetPopoverTrigger() {
       setIsOpen: (open: boolean) => setIsOpen(open),
     });
   }
+
+  // `cta.mode: 'transform'` — the CTA card IS the launcher while visible.
+  // When the card goes away (dismissed, URL mismatch, delay pending) the
+  // bubble returns so the visitor always has an entry point.
+  if (config.cta?.mode === 'transform' && ctaVisible) return null;
 
   return (
     <IFrame

--- a/packages/react/src/__tests__/cta-card.spec.tsx
+++ b/packages/react/src/__tests__/cta-card.spec.tsx
@@ -1,0 +1,148 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { CtaButton, CtaConfig } from '@opencx/widget-core';
+import { CtaCard } from '../CtaCard';
+
+const noop = () => undefined;
+
+const baseCta: CtaConfig = {
+  title: 'Do you have any questions?',
+  body: 'The team is online.',
+  avatarUrls: ['https://x.com/a.png', 'https://x.com/b.png'],
+  buttons: [
+    { text: 'Chat with us', action: 'open-chat' },
+    { text: 'Sign up free', action: 'url', url: 'https://x.com/signup' },
+  ],
+  composer: { placeholder: 'Write a message…' },
+};
+
+suite('CtaCard', () => {
+  test('renders title, body, image, avatars, and all buttons', () => {
+    render(
+      <CtaCard
+        cta={{ ...baseCta, imageUrl: 'https://x.com/hero.png' }}
+        onButtonClick={noop}
+        onComposerSubmit={noop}
+        onDismiss={noop}
+      />,
+    );
+    expect(screen.getByText('Do you have any questions?')).toBeTruthy();
+    expect(screen.getByText('The team is online.')).toBeTruthy();
+    expect(screen.getByText('Chat with us')).toBeTruthy();
+    expect(screen.getByText('Sign up free')).toBeTruthy();
+    // hero image + 2 avatars
+    expect(document.querySelectorAll('img').length).toBe(3);
+  });
+
+  test('optional sections are omitted when not configured', () => {
+    render(
+      <CtaCard
+        cta={{ title: 'Hi' }}
+        onButtonClick={noop}
+        onComposerSubmit={noop}
+        onDismiss={noop}
+      />,
+    );
+    expect(document.querySelectorAll('img').length).toBe(0);
+    expect(document.querySelector('form')).toBeNull();
+    expect(document.querySelectorAll('[data-component="cta/btn"]').length).toBe(
+      0,
+    );
+  });
+
+  test('button click reports the button object and its index', () => {
+    const clicks: Array<{ button: CtaButton; index: number }> = [];
+    render(
+      <CtaCard
+        cta={baseCta}
+        onButtonClick={(button, index) => clicks.push({ button, index })}
+        onComposerSubmit={noop}
+        onDismiss={noop}
+      />,
+    );
+    fireEvent.click(screen.getByText('Sign up free'));
+    expect(clicks).toEqual([
+      {
+        button: { text: 'Sign up free', action: 'url', url: 'https://x.com/signup' },
+        index: 1,
+      },
+    ]);
+  });
+
+  test('dismiss X fires onDismiss', () => {
+    let dismissed = 0;
+    render(
+      <CtaCard
+        cta={baseCta}
+        onButtonClick={noop}
+        onComposerSubmit={noop}
+        onDismiss={() => dismissed++}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText('Dismiss'));
+    expect(dismissed).toBe(1);
+  });
+
+  test('composer submits trimmed text and clears the input', () => {
+    const sent: string[] = [];
+    render(
+      <CtaCard
+        cta={baseCta}
+        onButtonClick={noop}
+        onComposerSubmit={(text) => sent.push(text)}
+        onDismiss={noop}
+      />,
+    );
+    const input = screen.getByPlaceholderText('Write a message…');
+    fireEvent.change(input, { target: { value: '  hello  ' } });
+    fireEvent.submit(input.closest('form')!);
+    expect(sent).toEqual(['hello']);
+    expect(screen.getByPlaceholderText('Write a message…')).toHaveProperty(
+      'value',
+      '',
+    );
+  });
+
+  test('composer ignores empty / whitespace-only submissions', () => {
+    const sent: string[] = [];
+    render(
+      <CtaCard
+        cta={baseCta}
+        onButtonClick={noop}
+        onComposerSubmit={(text) => sent.push(text)}
+        onDismiss={noop}
+      />,
+    );
+    const input = screen.getByPlaceholderText('Write a message…');
+    fireEvent.change(input, { target: { value: '   ' } });
+    fireEvent.submit(input.closest('form')!);
+    expect(sent).toEqual([]);
+  });
+
+  test('every section carries its data-component name for cssOverrides', () => {
+    render(
+      <CtaCard
+        cta={{ ...baseCta, imageUrl: 'https://x.com/hero.png' }}
+        onButtonClick={noop}
+        onComposerSubmit={noop}
+        onDismiss={noop}
+      />,
+    );
+    for (const name of [
+      'cta/root',
+      'cta/dismiss_btn',
+      'cta/image',
+      'cta/title',
+      'cta/body',
+      'cta/avatars',
+      'cta/btn',
+      'cta/composer/root',
+      'cta/composer/input',
+      'cta/composer/send_btn',
+    ]) {
+      expect(
+        document.querySelector(`[data-component="${name}"]`),
+        `missing ${name}`,
+      ).toBeTruthy();
+    }
+  });
+});

--- a/packages/react/src/__tests__/cta-motion-variants.spec.ts
+++ b/packages/react/src/__tests__/cta-motion-variants.spec.ts
@@ -1,0 +1,53 @@
+import { makeCtaMotionVariants } from '../CtaContainer';
+
+suite('makeCtaMotionVariants', () => {
+  test('full motion: blob and droplet-shown use interruptible springs', () => {
+    const v = makeCtaMotionVariants(false);
+    expect(v.blob.shown.transition).toMatchObject({ type: 'spring' });
+    expect(v.blob.hidden.transition).toMatchObject({ type: 'spring' });
+    expect(v.droplet.shown.transition).toMatchObject({ type: 'spring' });
+  });
+
+  test('full motion: blob collapses toward the corner, content fades fast', () => {
+    const v = makeCtaMotionVariants(false);
+    expect(v.blob.shown).toMatchObject({ scale: 1, x: 0, y: 0 });
+    expect(v.blob.hidden.scale).toBeLessThan(0.1);
+    expect(v.blob.hidden.x).toBeGreaterThan(0);
+    expect(v.blob.hidden.y).toBeGreaterThan(0);
+    // content exits quicker than it re-enters (text must never sit in the goo)
+    expect(v.content.hidden.transition.duration).toBeLessThan(
+      v.content.shown.transition.duration + v.content.shown.transition.delay,
+    );
+  });
+
+  test('full motion: droplet swells then vanishes (keyframes) on hide', () => {
+    const v = makeCtaMotionVariants(false);
+    expect(v.droplet.hidden.scale).toEqual([1.4, 0]);
+  });
+
+  test('reduced motion: every transition is an instant swap', () => {
+    const v = makeCtaMotionVariants(true);
+    for (const group of [v.blob, v.droplet, v.content]) {
+      expect(group.shown.transition).toEqual({ duration: 0 });
+      expect(group.hidden.transition).toEqual({ duration: 0 });
+    }
+  });
+
+  test('reduced motion: droplet never animates keyframes', () => {
+    const v = makeCtaMotionVariants(true);
+    expect(v.droplet.hidden.scale).toBe(0);
+  });
+
+  test('end states are identical regardless of reduced-motion (same UI, different journey)', () => {
+    const full = makeCtaMotionVariants(false);
+    const reduced = makeCtaMotionVariants(true);
+    const strip = (o: object) =>
+      JSON.parse(
+        JSON.stringify(o, (k, v: unknown) =>
+          k === 'transition' || k === 'scale' ? undefined : v,
+        ),
+      );
+    expect(strip(full.blob)).toEqual(strip(reduced.blob));
+    expect(strip(full.content)).toEqual(strip(reduced.content));
+  });
+});

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -14,6 +14,7 @@ import {
 import { AgentMessageDefaultComponent } from './components/custom-components/AgentMessageDefaultComponent';
 import { FallbackDefaultComponent } from './components/custom-components/FallbackDefaultComponent';
 import { LoadingDefaultComponent } from './components/custom-components/LoadingDefaultComponent';
+import { CtaContainer } from './CtaContainer';
 import { WidgetContent, WidgetPopoverContent } from './WidgetPopoverContent';
 import { WidgetPopoverTrigger } from './WidgetPopoverTrigger';
 import { WidgetPopoverAnchor } from './WidgetPopoverAnchor';
@@ -26,11 +27,14 @@ function WidgetPopoverTriggerAndContent() {
   const { isOpen, setIsOpen } = useWidgetTrigger();
 
   return (
-    <PopoverPrimitive.Root open={isOpen} onOpenChange={setIsOpen}>
-      <WidgetPopoverAnchor />
-      <WidgetPopoverTrigger />
-      <WidgetPopoverContent />
-    </PopoverPrimitive.Root>
+    <>
+      <CtaContainer />
+      <PopoverPrimitive.Root open={isOpen} onOpenChange={setIsOpen}>
+        <WidgetPopoverAnchor />
+        <WidgetPopoverTrigger />
+        <WidgetPopoverContent />
+      </PopoverPrimitive.Root>
+    </>
   );
 }
 

--- a/packages/react/src/screens/chat/ChatFooter.tsx
+++ b/packages/react/src/screens/chat/ChatFooter.tsx
@@ -1,5 +1,6 @@
 import { type SendMessageDto } from '@opencx/widget-core';
 import {
+  useComposerDraft,
   useConfig,
   useCsat,
   useIsAwaitingBotReply,
@@ -142,7 +143,16 @@ function ChatInput() {
   const { sessionState } = useSessions();
   const { disableSendingWhenAwaitingAIReply } = useConfig();
   const { t } = useTranslation();
-  const [inputText, setInputText] = useState('');
+  // Composer draft lives in core state so it can be set programmatically (the
+  // host-facing `prefill` trigger) as well as by typing here.
+  const { draft: inputText, setDraft: setInputText } = useComposerDraft();
+
+  // When the composer mounts already holding draft text (e.g. set by `prefill`
+  // before navigating to chat), focus it so the visitor can just press Enter.
+  useEffect(() => {
+    if (inputText.trim()) inputRef.current?.focus();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const {
     allFiles,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,22 +162,22 @@ importers:
         version: link:../react-headless
       '@radix-ui/react-avatar':
         specifier: ^1.1.0
-        version: 1.1.10(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 1.1.10(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.4
-        version: 2.1.15(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 2.1.15(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-popover':
         specifier: ^1.1.2
-        version: 1.1.14(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 1.1.14(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-slot':
         specifier: ^1.1.0
         version: 1.2.3(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-switch':
         specifier: ^1.1.0
-        version: 1.2.5(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 1.2.5(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-tooltip':
         specifier: ^1.1.2
-        version: 1.2.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 1.2.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
       '@types/react':
         specifier: '>=18 <20'
         version: 19.1.9
@@ -186,7 +186,7 @@ importers:
         version: 19.1.7(@types/react@19.1.9)
       '@uiw/react-iframe':
         specifier: ^1.0.3
-        version: 1.0.4(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 1.0.4(react@19.1.1)
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.1
@@ -195,7 +195,7 @@ importers:
         version: 2.1.1
       framer-motion:
         specifier: ^11.3.30
-        version: 11.18.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 11.18.2(react@19.1.1)
       lucide-react:
         specifier: ^0.436.0
         version: 0.436.0(react@19.1.1)
@@ -213,7 +213,7 @@ importers:
         version: 9.1.0(@types/react@19.1.9)(react@19.1.1)
       react-use:
         specifier: ^17.5.1
-        version: 17.6.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 17.6.0(react@19.1.1)
       rehype-raw:
         specifier: ^7.0.0
         version: 7.0.0
@@ -239,9 +239,18 @@ importers:
       '@tailwindcss/typography':
         specifier: ^0.5.15
         version: 0.5.16(tailwindcss@3.4.17)
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
       '@types/tinycolor2':
         specifier: ^1.4.6
         version: 1.4.6
+      '@vitejs/plugin-react-swc':
+        specifier: ^4.0.0
+        version: 4.0.0(vite@5.4.19(@types/node@20.19.10))
+      jsdom:
+        specifier: ^25.0.1
+        version: 25.0.1
       postcss:
         specifier: ^8.4.41
         version: 8.5.6
@@ -254,6 +263,12 @@ importers:
       vite-plugin-qrcode:
         specifier: ^0.3.0
         version: 0.3.0(vite@5.4.19(@types/node@20.19.10))
+      vite-tsconfig-paths:
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@5.9.2)(vite@5.4.19(@types/node@20.19.10))
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.10)(jsdom@25.0.1)
 
   packages/react-headless:
     dependencies:
@@ -1245,8 +1260,30 @@ packages:
     peerDependencies:
       tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@types/argparse@1.0.38':
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
@@ -1525,6 +1562,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
@@ -1548,6 +1589,9 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
@@ -1835,6 +1879,9 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dotenv-cli@10.0.0:
     resolution: {integrity: sha512-lnOnttzfrzkRx2echxJHQRB6vOAMSCzzZg79IxpC00tU42wZPuZkQxNNrrwVAxaQZIIh001l4PxVlCrBxngBzA==}
@@ -2619,6 +2666,10 @@ packages:
   lucide@0.525.0:
     resolution: {integrity: sha512-sfehWlaE/7NVkcEQ4T9JD3eID8RNMIGJBBUq9wF3UFiJIrcMKRbU3g1KGfDk4svcW7yw8BtDLXaXo02scDtUYQ==}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
@@ -3074,6 +3125,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -3110,6 +3165,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-markdown@9.1.0:
     resolution: {integrity: sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==}
@@ -3577,6 +3635,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -4259,11 +4318,10 @@ snapshots:
       '@floating-ui/core': 1.7.3
       '@floating-ui/utils': 0.2.10
 
-  '@floating-ui/react-dom@2.1.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@floating-ui/react-dom@2.1.5(react@19.1.1)':
     dependencies:
       '@floating-ui/dom': 1.7.3
       react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
 
   '@floating-ui/utils@0.2.10': {}
 
@@ -4373,36 +4431,33 @@ snapshots:
 
   '@radix-ui/primitive@1.1.2': {}
 
-  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
       react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
     optionalDependencies:
       '@types/react': 19.1.9
       '@types/react-dom': 19.1.7(@types/react@19.1.9)
 
-  '@radix-ui/react-avatar@1.1.10(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@radix-ui/react-avatar@1.1.10(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)':
     dependencies:
       '@radix-ui/react-context': 1.1.2(@types/react@19.1.9)(react@19.1.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.9)(react@19.1.1)
       react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
     optionalDependencies:
       '@types/react': 19.1.9
       '@types/react-dom': 19.1.7(@types/react@19.1.9)
 
-  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-context': 1.1.2(@types/react@19.1.9)(react@19.1.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-slot': 1.2.3(@types/react@19.1.9)(react@19.1.1)
       react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
     optionalDependencies:
       '@types/react': 19.1.9
       '@types/react-dom': 19.1.7(@types/react@19.1.9)
@@ -4425,30 +4480,28 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.9
 
-  '@radix-ui/react-dismissable-layer@1.1.10(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@radix-ui/react-dismissable-layer@1.1.10(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.2
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.9)(react@19.1.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.1.9)(react@19.1.1)
       react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
     optionalDependencies:
       '@types/react': 19.1.9
       '@types/react-dom': 19.1.7(@types/react@19.1.9)
 
-  '@radix-ui/react-dropdown-menu@2.1.15(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@radix-ui/react-dropdown-menu@2.1.15(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.2
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-context': 1.1.2(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-id': 1.1.1(@types/react@19.1.9)(react@19.1.1)
-      '@radix-ui/react-menu': 2.1.15(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-menu': 2.1.15(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.9)(react@19.1.1)
       react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
     optionalDependencies:
       '@types/react': 19.1.9
       '@types/react-dom': 19.1.7(@types/react@19.1.9)
@@ -4459,13 +4512,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.9
 
-  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.9)(react@19.1.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.9)(react@19.1.1)
       react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
     optionalDependencies:
       '@types/react': 19.1.9
       '@types/react-dom': 19.1.7(@types/react@19.1.9)
@@ -4477,115 +4529,108 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.9
 
-  '@radix-ui/react-menu@2.1.15(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@radix-ui/react-menu@2.1.15(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.2
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-context': 1.1.2(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-direction': 1.1.1(@types/react@19.1.9)(react@19.1.1)
-      '@radix-ui/react-dismissable-layer': 1.1.10(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-dismissable-layer': 1.1.10(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-focus-guards': 1.1.2(@types/react@19.1.9)(react@19.1.1)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-id': 1.1.1(@types/react@19.1.9)(react@19.1.1)
-      '@radix-ui/react-popper': 1.2.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-roving-focus': 1.1.10(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-popper': 1.2.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
+      '@radix-ui/react-roving-focus': 1.1.10(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-slot': 1.2.3(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.9)(react@19.1.1)
       aria-hidden: 1.2.6
       react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
       react-remove-scroll: 2.7.1(@types/react@19.1.9)(react@19.1.1)
     optionalDependencies:
       '@types/react': 19.1.9
       '@types/react-dom': 19.1.7(@types/react@19.1.9)
 
-  '@radix-ui/react-popover@1.1.14(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@radix-ui/react-popover@1.1.14(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.2
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-context': 1.1.2(@types/react@19.1.9)(react@19.1.1)
-      '@radix-ui/react-dismissable-layer': 1.1.10(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-dismissable-layer': 1.1.10(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-focus-guards': 1.1.2(@types/react@19.1.9)(react@19.1.1)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-id': 1.1.1(@types/react@19.1.9)(react@19.1.1)
-      '@radix-ui/react-popper': 1.2.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-popper': 1.2.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-slot': 1.2.3(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.9)(react@19.1.1)
       aria-hidden: 1.2.6
       react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
       react-remove-scroll: 2.7.1(@types/react@19.1.9)(react@19.1.1)
     optionalDependencies:
       '@types/react': 19.1.9
       '@types/react-dom': 19.1.7(@types/react@19.1.9)
 
-  '@radix-ui/react-popper@1.2.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@radix-ui/react-popper@1.2.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@floating-ui/react-dom': 2.1.5(react@19.1.1)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-context': 1.1.2(@types/react@19.1.9)(react@19.1.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-use-rect': 1.1.1(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/rect': 1.1.1
       react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
     optionalDependencies:
       '@types/react': 19.1.9
       '@types/react-dom': 19.1.7(@types/react@19.1.9)
 
-  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.9)(react@19.1.1)
       react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
     optionalDependencies:
       '@types/react': 19.1.9
       '@types/react-dom': 19.1.7(@types/react@19.1.9)
 
-  '@radix-ui/react-presence@1.1.4(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@radix-ui/react-presence@1.1.4(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.9)(react@19.1.1)
       react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
     optionalDependencies:
       '@types/react': 19.1.9
       '@types/react-dom': 19.1.7(@types/react@19.1.9)
 
-  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)':
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.1.9)(react@19.1.1)
       react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
     optionalDependencies:
       '@types/react': 19.1.9
       '@types/react-dom': 19.1.7(@types/react@19.1.9)
 
-  '@radix-ui/react-roving-focus@1.1.10(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@radix-ui/react-roving-focus@1.1.10(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.2
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-context': 1.1.2(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-direction': 1.1.1(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-id': 1.1.1(@types/react@19.1.9)(react@19.1.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.9)(react@19.1.1)
       react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
     optionalDependencies:
       '@types/react': 19.1.9
       '@types/react-dom': 19.1.7(@types/react@19.1.9)
@@ -4597,37 +4642,35 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.9
 
-  '@radix-ui/react-switch@1.2.5(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@radix-ui/react-switch@1.2.5(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.2
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-context': 1.1.2(@types/react@19.1.9)(react@19.1.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.9)(react@19.1.1)
       react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
     optionalDependencies:
       '@types/react': 19.1.9
       '@types/react-dom': 19.1.7(@types/react@19.1.9)
 
-  '@radix-ui/react-tooltip@1.2.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@radix-ui/react-tooltip@1.2.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.2
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-context': 1.1.2(@types/react@19.1.9)(react@19.1.1)
-      '@radix-ui/react-dismissable-layer': 1.1.10(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-dismissable-layer': 1.1.10(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-id': 1.1.1(@types/react@19.1.9)(react@19.1.1)
-      '@radix-ui/react-popper': 1.2.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-popper': 1.2.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-slot': 1.2.3(@types/react@19.1.9)(react@19.1.1)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.9)(react@19.1.1)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
       react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
     optionalDependencies:
       '@types/react': 19.1.9
       '@types/react-dom': 19.1.7(@types/react@19.1.9)
@@ -4693,11 +4736,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.9
 
-  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)
       react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
     optionalDependencies:
       '@types/react': 19.1.9
       '@types/react-dom': 19.1.7(@types/react@19.1.9)
@@ -4891,7 +4933,29 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 3.4.17
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/runtime': 7.28.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react@19.1.1)':
+    dependencies:
+      '@babel/runtime': 7.28.2
+      '@testing-library/dom': 10.4.1
+      react: 19.1.1
+    optionalDependencies:
+      '@types/react': 19.1.9
+      '@types/react-dom': 19.1.7(@types/react@19.1.9)
+
   '@types/argparse@1.0.38': {}
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.2':
     dependencies:
@@ -5080,10 +5144,9 @@ snapshots:
       '@typescript-eslint/types': 8.39.0
       eslint-visitor-keys: 4.2.1
 
-  '@uiw/react-iframe@1.0.4(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@uiw/react-iframe@1.0.4(react@19.1.1)':
     dependencies:
       react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -5231,6 +5294,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.1: {}
 
   any-promise@1.3.0: {}
@@ -5251,6 +5316,10 @@ snapshots:
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   array-buffer-byte-length@1.0.2:
     dependencies:
@@ -5547,6 +5616,8 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dom-accessibility-api@0.5.16: {}
+
   dotenv-cli@10.0.0:
     dependencies:
       cross-spawn: 7.0.6
@@ -5611,7 +5682,7 @@ snapshots:
       has-property-descriptors: 1.0.2
       has-proto: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       internal-slot: 1.1.0
       is-array-buffer: 3.0.5
       is-callable: 1.2.7
@@ -5678,11 +5749,11 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   es-shim-unscopables@1.1.0:
     dependencies:
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   es-to-primitive@1.3.0:
     dependencies:
@@ -5941,14 +6012,13 @@ snapshots:
       hasown: 2.0.4
       mime-types: 2.1.35
 
-  framer-motion@11.18.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+  framer-motion@11.18.2(react@19.1.1):
     dependencies:
       motion-dom: 11.18.1
       motion-utils: 11.18.1
       tslib: 2.8.1
     optionalDependencies:
       react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
 
   fs-extra@7.0.1:
     dependencies:
@@ -5973,7 +6043,7 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       functions-have-names: 1.2.3
-      hasown: 2.0.2
+      hasown: 2.0.4
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
@@ -5988,7 +6058,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-nonce@1.0.1: {}
@@ -6206,7 +6276,7 @@ snapshots:
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       side-channel: 1.1.0
 
   is-alphabetical@2.0.1: {}
@@ -6247,7 +6317,7 @@ snapshots:
 
   is-core-module@2.16.1:
     dependencies:
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   is-data-view@1.0.2:
     dependencies:
@@ -6303,7 +6373,7 @@ snapshots:
       call-bound: 1.0.4
       gopd: 1.2.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   is-set@2.0.3: {}
 
@@ -6489,6 +6559,8 @@ snapshots:
       react: 19.1.1
 
   lucide@0.525.0: {}
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.17:
     dependencies:
@@ -6902,7 +6974,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nano-css@5.6.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+  nano-css@5.6.2(react@19.1.1):
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.4
       css-tree: 1.1.3
@@ -6910,7 +6982,6 @@ snapshots:
       fastest-stable-stringify: 2.0.2
       inline-style-prefixer: 7.0.1
       react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
       rtl-css-js: 1.16.1
       stacktrace-js: 2.0.2
       stylis: 4.3.6
@@ -7143,6 +7214,12 @@ snapshots:
 
   prettier@3.6.2: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -7174,6 +7251,8 @@ snapshots:
       react: 19.1.1
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-markdown@9.1.0(@types/react@19.1.9)(react@19.1.1):
     dependencies:
@@ -7225,7 +7304,7 @@ snapshots:
       react: 19.1.1
       tslib: 2.8.1
 
-  react-use@17.6.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+  react-use@17.6.0(react@19.1.1):
     dependencies:
       '@types/js-cookie': 2.2.7
       '@xobotyi/scrollbar-width': 1.9.5
@@ -7233,9 +7312,8 @@ snapshots:
       fast-deep-equal: 3.1.3
       fast-shallow-equal: 1.0.0
       js-cookie: 2.2.1
-      nano-css: 5.6.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      nano-css: 5.6.2(react@19.1.1)
       react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
       react-universal-interface: 0.6.2(react@19.1.1)(tslib@2.8.1)
       resize-observer-polyfill: 1.5.1
       screenfull: 5.2.0


### PR DESCRIPTION
> **Stacked on #28** (host-page trigger API) — the diff includes #28's commits until it merges; review only the commits after `7c8d873`. Draft until #28 lands.

## What

A declarative **Chat CTA card** near the launcher — the Crisp/Text-style proactive teaser — configured entirely from `WidgetConfig`:

```js
initOpenScript({
  token: '...',
  cta: {
    title: 'Do you have any questions? 😀',
    body: 'The team is online and typically replies in minutes.',
    avatarUrls: ['...'],
    buttons: [
      { text: 'Chat with the team', action: 'open-chat' },
      { text: 'How do earnings work?', action: 'ask', message: 'How do earnings work?' },
      { text: 'Sign up free', action: 'url', url: 'https://open.cx' },
    ],
    composer: { placeholder: 'Write a message…' }, // inline input → sends into a fresh chat
    dismissForDays: 7,
  },
});
```

- Button actions: `open-chat` / `ask` (send now) / `prefill` (draft) / `url`
- **Inline composer in the card** — visitor types and hits Enter, lands in a fresh chat with the message sent
- Dismiss X with localStorage persistence (`dismissForDays`, omit = forever)
- Show rules: `showAfterSeconds`, `urlMatch` (substring of `location.href`)
- Hooks: `onCtaDisplayed` / `onCtaClicked` / `onCtaDismissed`
- Host API: `showCta()` / `hideCta()` on `WidgetRef` and `window.opencxWidget` (force-show bypasses dismissal/rules)
- Styleable via the standard `cssOverrides` mechanism — ten new `cta/*` component names

## How

- **core**: pure visibility resolution (`resolveCtaVisible`, dismissal records, URL match) + a `ctaOverride` PrimitiveState on `WidgetCtx` (not cleared by `resetChat`)
- **react**: presentational `CtaCard` + `CtaContainer` glue rendered in its own style-isolated iframe (sized by a callback-ref ResizeObserver), mounted beside the popover for non-inline widgets
- **embed**: controller passthrough + playground example

## Tests

106 across the three packages (core 86, react 7 — first test harness for the react package, embed 13), zero test doubles. Verified live in the playground against the real API: open/ask/composer/url actions, dismiss persistence across reload, `showCta`/`hideCta`, `urlMatch`, `cssOverrides`.
