### PR TITLE
Translate widget footer tooltips

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @opencx/widget-core
 
+## 4.0.56
+
+### Patch Changes
+
+- added translations for the tooltips
+
 ## 4.0.55
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencx/widget-core",
   "private": false,
-  "version": "4.0.55",
+  "version": "4.0.56",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/core/src/translation/ar.ts
+++ b/packages/core/src/translation/ar.ts
@@ -20,4 +20,7 @@ export const ArabicLanguage: TranslationInterface = {
   csat_title: 'كيف كانت محادثتك؟',
   csat_submitted_title: 'لقد قيّمت المحادثة بـ',
   csat_feedback_placeholder: 'أخبرنا المزيد... (اختياري)',
+  send_message: 'إرسال الرسالة',
+  attach_file_tooltip: 'إرفاق صور أو ملفات PDF أو جداول بيانات (الحد الأقصى للحجم 5 ميجابايت)',
+  failed_to_upload: 'فشل الرفع:',
 };

--- a/packages/core/src/translation/bg.ts
+++ b/packages/core/src/translation/bg.ts
@@ -20,4 +20,7 @@ export const BulgarianLanguage: TranslationInterface = {
   csat_title: 'Как мина разговорът ви?',
   csat_submitted_title: 'Оценихте разговора като',
   csat_feedback_placeholder: 'Кажете ни повече... (по желание)',
+  send_message: 'Изпращане на съобщение',
+  attach_file_tooltip: 'Прикачване на изображения, PDF файлове или таблици (максимален размер 5 МБ)',
+  failed_to_upload: 'Неуспешно качване:',
 };

--- a/packages/core/src/translation/bn.ts
+++ b/packages/core/src/translation/bn.ts
@@ -20,4 +20,7 @@ export const BengaliLanguage: TranslationInterface = {
   csat_title: 'আপনার কথোপকথন কেমন ছিল?',
   csat_submitted_title: 'আপনি কথোপকথনটি মূল্যায়ন করেছেন',
   csat_feedback_placeholder: 'আমাদের আরও বলুন... (ঐচ্ছিক)',
+  send_message: 'বার্তা পাঠান',
+  attach_file_tooltip: 'ছবি, PDF বা স্প্রেডশিট সংযুক্ত করুন (সর্বোচ্চ আকার 5 এমবি)',
+  failed_to_upload: 'আপলোড ব্যর্থ হয়েছে:',
 };

--- a/packages/core/src/translation/cs.ts
+++ b/packages/core/src/translation/cs.ts
@@ -20,4 +20,7 @@ export const CzechLanguage: TranslationInterface = {
   csat_title: 'Jaká byla vaše konverzace?',
   csat_submitted_title: 'Konverzaci jste ohodnotili jako',
   csat_feedback_placeholder: 'Řekněte nám více... (nepovinné)',
+  send_message: 'Odeslat zprávu',
+  attach_file_tooltip: 'Připojit obrázky, PDF nebo tabulky (maximální velikost 5 MB)',
+  failed_to_upload: 'Nahrání se nezdařilo:',
 };

--- a/packages/core/src/translation/da.ts
+++ b/packages/core/src/translation/da.ts
@@ -20,4 +20,7 @@ export const DanishLanguage: TranslationInterface = {
   csat_title: 'Hvordan var din samtale?',
   csat_submitted_title: 'Du vurderede samtalen som',
   csat_feedback_placeholder: 'Fortæl os mere... (valgfrit)',
+  send_message: 'Send besked',
+  attach_file_tooltip: 'Vedhæft billeder, PDF-filer eller regneark (maksimal størrelse 5 MB)',
+  failed_to_upload: 'Upload mislykkedes:',
 };

--- a/packages/core/src/translation/de.ts
+++ b/packages/core/src/translation/de.ts
@@ -20,4 +20,7 @@ export const GermanLanguage: TranslationInterface = {
   csat_title: 'Wie war Ihr Gespräch?',
   csat_submitted_title: 'Sie haben das Gespräch bewertet als',
   csat_feedback_placeholder: 'Erzählen Sie uns mehr... (optional)',
+  send_message: 'Nachricht senden',
+  attach_file_tooltip: 'Bilder, PDFs oder Tabellen anhängen (maximale Größe 5 MB)',
+  failed_to_upload: 'Hochladen fehlgeschlagen:',
 };

--- a/packages/core/src/translation/el.ts
+++ b/packages/core/src/translation/el.ts
@@ -20,4 +20,7 @@ export const GreekLanguage: TranslationInterface = {
   csat_title: 'Πώς ήταν η συνομιλία σας;',
   csat_submitted_title: 'Βαθμολογήσατε τη συνομιλία ως',
   csat_feedback_placeholder: 'Πείτε μας περισσότερα... (προαιρετικό)',
+  send_message: 'Αποστολή μηνύματος',
+  attach_file_tooltip: 'Επισύναψη εικόνων, PDF ή υπολογιστικών φύλλων (μέγιστο μέγεθος 5 MB)',
+  failed_to_upload: 'Η μεταφόρτωση απέτυχε:',
 };

--- a/packages/core/src/translation/en.ts
+++ b/packages/core/src/translation/en.ts
@@ -20,4 +20,7 @@ export const EnglishLanguage: TranslationInterface = {
   csat_title: 'How was your conversation?',
   csat_submitted_title: 'You rated the conversation as',
   csat_feedback_placeholder: 'Tell us more... (optional)',
+  send_message: 'Send message',
+  attach_file_tooltip: 'Attach images, PDFs, or spreadsheets (maximum size 5mb)',
+  failed_to_upload: 'Failed to upload:',
 };

--- a/packages/core/src/translation/es.ts
+++ b/packages/core/src/translation/es.ts
@@ -20,4 +20,7 @@ export const SpanishLanguage: TranslationInterface = {
   csat_title: '¿Qué tal fue tu conversación?',
   csat_submitted_title: 'Valoraste la conversación como',
   csat_feedback_placeholder: 'Cuéntanos más... (opcional)',
+  send_message: 'Enviar mensaje',
+  attach_file_tooltip: 'Adjuntar imágenes, PDF u hojas de cálculo (tamaño máximo 5 MB)',
+  failed_to_upload: 'Error al subir:',
 };

--- a/packages/core/src/translation/et.ts
+++ b/packages/core/src/translation/et.ts
@@ -20,4 +20,7 @@ export const EstonianLanguage: TranslationInterface = {
   csat_title: 'Milline oli teie vestlus?',
   csat_submitted_title: 'Hindasite vestlust kui',
   csat_feedback_placeholder: 'Rääkige meile rohkem... (valikuline)',
+  send_message: 'Saada sõnum',
+  attach_file_tooltip: 'Lisa pilte, PDF-e või tabeleid (maksimaalne suurus 5 MB)',
+  failed_to_upload: 'Üleslaadimine ebaõnnestus:',
 };

--- a/packages/core/src/translation/fi.ts
+++ b/packages/core/src/translation/fi.ts
@@ -20,4 +20,7 @@ export const FinnishLanguage: TranslationInterface = {
   csat_title: 'Millainen keskustelusi oli?',
   csat_submitted_title: 'Arvioit keskustelun',
   csat_feedback_placeholder: 'Kerro lisää... (valinnainen)',
+  send_message: 'Lähetä viesti',
+  attach_file_tooltip: 'Liitä kuvia, PDF-tiedostoja tai taulukoita (enimmäiskoko 5 Mt)',
+  failed_to_upload: 'Lataus epäonnistui:',
 };

--- a/packages/core/src/translation/fil.ts
+++ b/packages/core/src/translation/fil.ts
@@ -20,4 +20,7 @@ export const FilipinoLanguage: TranslationInterface = {
   csat_title: 'Kumusta ang iyong usapan?',
   csat_submitted_title: 'Ni-rate mo ang usapan bilang',
   csat_feedback_placeholder: 'Sabihin pa sa amin... (opsyonal)',
+  send_message: 'Ipadala ang mensahe',
+  attach_file_tooltip: 'Maglakip ng mga larawan, PDF, o spreadsheet (maximum na laki 5mb)',
+  failed_to_upload: 'Nabigo ang pag-upload:',
 };

--- a/packages/core/src/translation/fr.ts
+++ b/packages/core/src/translation/fr.ts
@@ -20,4 +20,7 @@ export const FrenchLanguage: TranslationInterface = {
   csat_title: 'Comment s’est passée votre conversation ?',
   csat_submitted_title: 'Vous avez évalué la conversation comme',
   csat_feedback_placeholder: 'Dites-nous en plus... (facultatif)',
+  send_message: 'Envoyer le message',
+  attach_file_tooltip: 'Joindre des images, des PDF ou des feuilles de calcul (taille maximale 5 Mo)',
+  failed_to_upload: 'Échec du téléchargement :',
 };

--- a/packages/core/src/translation/hi.ts
+++ b/packages/core/src/translation/hi.ts
@@ -20,4 +20,7 @@ export const HindiLanguage: TranslationInterface = {
   csat_title: 'आपकी बातचीत कैसी रही?',
   csat_submitted_title: 'आपने बातचीत को आंका',
   csat_feedback_placeholder: 'हमें और बताएं... (वैकल्पिक)',
+  send_message: 'संदेश भेजें',
+  attach_file_tooltip: 'छवियाँ, PDF या स्प्रेडशीट संलग्न करें (अधिकतम आकार 5 एमबी)',
+  failed_to_upload: 'अपलोड विफल:',
 };

--- a/packages/core/src/translation/hr.ts
+++ b/packages/core/src/translation/hr.ts
@@ -20,4 +20,7 @@ export const CroatianLanguage: TranslationInterface = {
   csat_title: 'Kakav je bio vaš razgovor?',
   csat_submitted_title: 'Ocijenili ste razgovor kao',
   csat_feedback_placeholder: 'Recite nam više... (neobavezno)',
+  send_message: 'Pošalji poruku',
+  attach_file_tooltip: 'Priloži slike, PDF-ove ili proračunske tablice (najveća veličina 5 MB)',
+  failed_to_upload: 'Prijenos nije uspio:',
 };

--- a/packages/core/src/translation/hu.ts
+++ b/packages/core/src/translation/hu.ts
@@ -20,4 +20,7 @@ export const HungarianLanguage: TranslationInterface = {
   csat_title: 'Milyen volt a beszélgetése?',
   csat_submitted_title: 'A beszélgetést így értékelte',
   csat_feedback_placeholder: 'Mondjon többet... (opcionális)',
+  send_message: 'Üzenet küldése',
+  attach_file_tooltip: 'Képek, PDF-ek vagy táblázatok csatolása (maximális méret 5 MB)',
+  failed_to_upload: 'A feltöltés sikertelen:',
 };

--- a/packages/core/src/translation/index.ts
+++ b/packages/core/src/translation/index.ts
@@ -115,5 +115,8 @@ export type TranslationInterface = {
   csat_title: string;
   csat_submitted_title: string;
   csat_feedback_placeholder: string;
+  send_message: string;
+  attach_file_tooltip: string;
+  failed_to_upload: string;
 };
 export type TranslationKeyU = keyof TranslationInterface;

--- a/packages/core/src/translation/is.ts
+++ b/packages/core/src/translation/is.ts
@@ -20,4 +20,7 @@ export const IcelandicLanguage: TranslationInterface = {
   csat_title: 'Hvernig var samtalið þitt?',
   csat_submitted_title: 'Þú gafst samtalinu einkunnina',
   csat_feedback_placeholder: 'Segðu okkur meira... (valfrjálst)',
+  send_message: 'Senda skilaboð',
+  attach_file_tooltip: 'Hengja við myndir, PDF eða töflureikna (hámarksstærð 5 MB)',
+  failed_to_upload: 'Upphleðsla mistókst:',
 };

--- a/packages/core/src/translation/it.ts
+++ b/packages/core/src/translation/it.ts
@@ -20,4 +20,7 @@ export const ItalianLanguage: TranslationInterface = {
   csat_title: 'Com’è andata la tua conversazione?',
   csat_submitted_title: 'Hai valutato la conversazione come',
   csat_feedback_placeholder: 'Dicci di più... (facoltativo)',
+  send_message: 'Invia messaggio',
+  attach_file_tooltip: 'Allega immagini, PDF o fogli di calcolo (dimensione massima 5 MB)',
+  failed_to_upload: 'Caricamento non riuscito:',
 };

--- a/packages/core/src/translation/ja.ts
+++ b/packages/core/src/translation/ja.ts
@@ -20,4 +20,7 @@ export const JapaneseLanguage: TranslationInterface = {
   csat_title: '会話はいかがでしたか？',
   csat_submitted_title: '会話を次のように評価しました',
   csat_feedback_placeholder: '詳しく教えてください...（任意）',
+  send_message: 'メッセージを送信',
+  attach_file_tooltip: '画像、PDF、スプレッドシートを添付（最大サイズ5MB）',
+  failed_to_upload: 'アップロードに失敗しました:',
 };

--- a/packages/core/src/translation/ko.ts
+++ b/packages/core/src/translation/ko.ts
@@ -20,4 +20,7 @@ export const KoreanLanguage: TranslationInterface = {
   csat_title: '대화는 어떠셨나요?',
   csat_submitted_title: '대화를 다음과 같이 평가했습니다',
   csat_feedback_placeholder: '더 알려주세요... (선택 사항)',
+  send_message: '메시지 보내기',
+  attach_file_tooltip: '이미지, PDF 또는 스프레드시트 첨부 (최대 크기 5MB)',
+  failed_to_upload: '업로드 실패:',
 };

--- a/packages/core/src/translation/lb.ts
+++ b/packages/core/src/translation/lb.ts
@@ -20,4 +20,7 @@ export const LuxembourgishLanguage: TranslationInterface = {
   csat_title: 'Wéi war Är Konversatioun?',
   csat_submitted_title: 'Dir hutt d’Konversatioun bewäert als',
   csat_feedback_placeholder: 'Sot eis méi... (fakultativ)',
+  send_message: 'Message schécken',
+  attach_file_tooltip: 'Biller, PDFen oder Tabellen unhänken (maximal Gréisst 5 MB)',
+  failed_to_upload: 'Eroplueden feelgeschloen:',
 };

--- a/packages/core/src/translation/lt.ts
+++ b/packages/core/src/translation/lt.ts
@@ -20,4 +20,7 @@ export const LithuanianLanguage: TranslationInterface = {
   csat_title: 'Koks buvo jūsų pokalbis?',
   csat_submitted_title: 'Pokalbį įvertinote kaip',
   csat_feedback_placeholder: 'Papasakokite daugiau... (neprivaloma)',
+  send_message: 'Siųsti žinutę',
+  attach_file_tooltip: 'Pridėti vaizdų, PDF arba skaičiuoklių (didžiausias dydis 5 MB)',
+  failed_to_upload: 'Nepavyko įkelti:',
 };

--- a/packages/core/src/translation/lv.ts
+++ b/packages/core/src/translation/lv.ts
@@ -20,4 +20,7 @@ export const LatvianLanguage: TranslationInterface = {
   csat_title: 'Kāda bija jūsu saruna?',
   csat_submitted_title: 'Jūs novērtējāt sarunu kā',
   csat_feedback_placeholder: 'Pastāstiet mums vairāk... (neobligāti)',
+  send_message: 'Sūtīt ziņojumu',
+  attach_file_tooltip: 'Pievienot attēlus, PDF vai izklājlapas (maksimālais izmērs 5 MB)',
+  failed_to_upload: 'Augšupielāde neizdevās:',
 };

--- a/packages/core/src/translation/mt.ts
+++ b/packages/core/src/translation/mt.ts
@@ -20,4 +20,7 @@ export const MalteseLanguage: TranslationInterface = {
   csat_title: 'Kif kienet il-konversazzjoni tiegħek?',
   csat_submitted_title: 'Int ivvalutajt il-konversazzjoni bħala',
   csat_feedback_placeholder: 'Għidilna aktar... (mhux obbligatorju)',
+  send_message: 'Ibgħat messaġġ',
+  attach_file_tooltip: 'Ehmeż stampi, PDFs, jew spreadsheets (daqs massimu 5mb)',
+  failed_to_upload: 'It-tlgħ falla:',
 };

--- a/packages/core/src/translation/nb.ts
+++ b/packages/core/src/translation/nb.ts
@@ -20,4 +20,7 @@ export const NorwegianBokmalLanguage: TranslationInterface = {
   csat_title: 'Hvordan var samtalen din?',
   csat_submitted_title: 'Du vurderte samtalen som',
   csat_feedback_placeholder: 'Fortell oss mer... (valgfritt)',
+  send_message: 'Send melding',
+  attach_file_tooltip: 'Legg ved bilder, PDF-er eller regneark (maksimal størrelse 5 MB)',
+  failed_to_upload: 'Opplasting mislyktes:',
 };

--- a/packages/core/src/translation/nl.ts
+++ b/packages/core/src/translation/nl.ts
@@ -20,4 +20,7 @@ export const DutchLanguage: TranslationInterface = {
   csat_title: 'Hoe was je gesprek?',
   csat_submitted_title: 'Je hebt het gesprek beoordeeld als',
   csat_feedback_placeholder: 'Vertel ons meer... (optioneel)',
+  send_message: 'Bericht versturen',
+  attach_file_tooltip: "Afbeeldingen, PDF's of spreadsheets bijvoegen (maximale grootte 5 MB)",
+  failed_to_upload: 'Uploaden mislukt:',
 };

--- a/packages/core/src/translation/no.ts
+++ b/packages/core/src/translation/no.ts
@@ -20,4 +20,7 @@ export const NorwegianLanguage: TranslationInterface = {
   csat_title: 'Hvordan var samtalen din?',
   csat_submitted_title: 'Du vurderte samtalen som',
   csat_feedback_placeholder: 'Fortell oss mer... (valgfritt)',
+  send_message: 'Send melding',
+  attach_file_tooltip: 'Legg ved bilder, PDF-er eller regneark (maksimal størrelse 5 MB)',
+  failed_to_upload: 'Opplasting mislyktes:',
 };

--- a/packages/core/src/translation/pl.ts
+++ b/packages/core/src/translation/pl.ts
@@ -20,4 +20,7 @@ export const PolishLanguage: TranslationInterface = {
   csat_title: 'Jak przebiegła Twoja rozmowa?',
   csat_submitted_title: 'Oceniłeś rozmowę jako',
   csat_feedback_placeholder: 'Powiedz nam więcej... (opcjonalnie)',
+  send_message: 'Wyślij wiadomość',
+  attach_file_tooltip: 'Załącz obrazy, pliki PDF lub arkusze kalkulacyjne (maksymalny rozmiar 5 MB)',
+  failed_to_upload: 'Przesyłanie nie powiodło się:',
 };

--- a/packages/core/src/translation/pt.ts
+++ b/packages/core/src/translation/pt.ts
@@ -20,4 +20,7 @@ export const PortugueseLanguage: TranslationInterface = {
   csat_title: 'Como foi a sua conversa?',
   csat_submitted_title: 'Você avaliou a conversa como',
   csat_feedback_placeholder: 'Conte-nos mais... (opcional)',
+  send_message: 'Enviar mensagem',
+  attach_file_tooltip: 'Anexar imagens, PDFs ou planilhas (tamanho máximo 5 MB)',
+  failed_to_upload: 'Falha no envio:',
 };

--- a/packages/core/src/translation/ro.ts
+++ b/packages/core/src/translation/ro.ts
@@ -20,4 +20,7 @@ export const RomanianLanguage: TranslationInterface = {
   csat_title: 'Cum a fost conversația ta?',
   csat_submitted_title: 'Ai evaluat conversația ca',
   csat_feedback_placeholder: 'Spune-ne mai multe... (opțional)',
+  send_message: 'Trimite mesajul',
+  attach_file_tooltip: 'Atașează imagini, PDF-uri sau foi de calcul (dimensiune maximă 5 MB)',
+  failed_to_upload: 'Încărcarea a eșuat:',
 };

--- a/packages/core/src/translation/ru.ts
+++ b/packages/core/src/translation/ru.ts
@@ -20,4 +20,7 @@ export const RussianLanguage: TranslationInterface = {
   csat_title: 'Как прошёл ваш разговор?',
   csat_submitted_title: 'Вы оценили разговор как',
   csat_feedback_placeholder: 'Расскажите подробнее... (необязательно)',
+  send_message: 'Отправить сообщение',
+  attach_file_tooltip: 'Прикрепить изображения, PDF или таблицы (максимальный размер 5 МБ)',
+  failed_to_upload: 'Ошибка загрузки:',
 };

--- a/packages/core/src/translation/sk.ts
+++ b/packages/core/src/translation/sk.ts
@@ -20,4 +20,7 @@ export const SlovakLanguage: TranslationInterface = {
   csat_title: 'Aká bola vaša konverzácia?',
   csat_submitted_title: 'Konverzáciu ste ohodnotili ako',
   csat_feedback_placeholder: 'Povedzte nám viac... (nepovinné)',
+  send_message: 'Odoslať správu',
+  attach_file_tooltip: 'Priložiť obrázky, PDF alebo tabuľky (maximálna veľkosť 5 MB)',
+  failed_to_upload: 'Nahrávanie zlyhalo:',
 };

--- a/packages/core/src/translation/sv.ts
+++ b/packages/core/src/translation/sv.ts
@@ -20,4 +20,7 @@ export const SwedishLanguage: TranslationInterface = {
   csat_title: 'Hur var din konversation?',
   csat_submitted_title: 'Du betygsatte konversationen som',
   csat_feedback_placeholder: 'Berätta mer... (valfritt)',
+  send_message: 'Skicka meddelande',
+  attach_file_tooltip: 'Bifoga bilder, PDF-filer eller kalkylblad (maximal storlek 5 MB)',
+  failed_to_upload: 'Uppladdningen misslyckades:',
 };

--- a/packages/core/src/translation/th.ts
+++ b/packages/core/src/translation/th.ts
@@ -20,4 +20,7 @@ export const ThaiLanguage: TranslationInterface = {
   csat_title: 'การสนทนาของคุณเป็นอย่างไรบ้าง?',
   csat_submitted_title: 'คุณให้คะแนนการสนทนาว่า',
   csat_feedback_placeholder: 'บอกเราเพิ่มเติม... (ไม่บังคับ)',
+  send_message: 'ส่งข้อความ',
+  attach_file_tooltip: 'แนบรูปภาพ PDF หรือสเปรดชีต (ขนาดสูงสุด 5 MB)',
+  failed_to_upload: 'อัปโหลดไม่สำเร็จ:',
 };

--- a/packages/core/src/translation/tr.ts
+++ b/packages/core/src/translation/tr.ts
@@ -20,4 +20,7 @@ export const TurkishLanguage: TranslationInterface = {
   csat_title: 'Görüşmeniz nasıldı?',
   csat_submitted_title: 'Görüşmeyi şöyle değerlendirdiniz',
   csat_feedback_placeholder: 'Bize daha fazlasını anlatın... (isteğe bağlı)',
+  send_message: 'Mesaj gönder',
+  attach_file_tooltip: 'Resim, PDF veya elektronik tablo ekle (maksimum boyut 5 MB)',
+  failed_to_upload: 'Yükleme başarısız:',
 };

--- a/packages/core/src/translation/ur.ts
+++ b/packages/core/src/translation/ur.ts
@@ -20,4 +20,7 @@ export const UrduLanguage: TranslationInterface = {
   csat_title: 'آپ کی گفتگو کیسی رہی؟',
   csat_submitted_title: 'آپ نے گفتگو کو درجہ دیا',
   csat_feedback_placeholder: 'ہمیں مزید بتائیں... (اختیاری)',
+  send_message: 'پیغام بھیجیں',
+  attach_file_tooltip: 'تصاویر، PDF یا اسپریڈ شیٹس منسلک کریں (زیادہ سے زیادہ سائز 5 ایم بی)',
+  failed_to_upload: 'اپ لوڈ ناکام:',
 };

--- a/packages/core/src/translation/vi.ts
+++ b/packages/core/src/translation/vi.ts
@@ -20,4 +20,7 @@ export const VietnameseLanguage: TranslationInterface = {
   csat_title: 'Cuộc trò chuyện của bạn thế nào?',
   csat_submitted_title: 'Bạn đã đánh giá cuộc trò chuyện là',
   csat_feedback_placeholder: 'Cho chúng tôi biết thêm... (tùy chọn)',
+  send_message: 'Gửi tin nhắn',
+  attach_file_tooltip: 'Đính kèm hình ảnh, PDF hoặc bảng tính (kích thước tối đa 5 MB)',
+  failed_to_upload: 'Tải lên thất bại:',
 };

--- a/packages/core/src/translation/zh-cn.ts
+++ b/packages/core/src/translation/zh-cn.ts
@@ -20,4 +20,7 @@ export const ChineseSimplifiedLanguage: TranslationInterface = {
   csat_title: '您的对话感觉如何？',
   csat_submitted_title: '您将此对话评价为',
   csat_feedback_placeholder: '告诉我们更多...（可选）',
+  send_message: '发送消息',
+  attach_file_tooltip: '附加图片、PDF 或电子表格（最大 5MB）',
+  failed_to_upload: '上传失败：',
 };

--- a/packages/embed/CHANGELOG.md
+++ b/packages/embed/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @opencx/widget
 
+## 4.0.56
+
+### Patch Changes
+
+- added translations for the tooltips
+
 ## 4.0.55
 
 ### Patch Changes

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencx/widget",
   "private": false,
-  "version": "4.0.55",
+  "version": "4.0.56",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/react-headless/CHANGELOG.md
+++ b/packages/react-headless/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @opencx/widget-react-headless
 
+## 4.0.56
+
+### Patch Changes
+
+- added translations for the tooltips
+- Updated dependencies
+  - @opencx/widget-core@4.0.56
+
 ## 4.0.55
 
 ### Patch Changes

--- a/packages/react-headless/package.json
+++ b/packages/react-headless/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencx/widget-react-headless",
   "private": false,
-  "version": "4.0.55",
+  "version": "4.0.56",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @opencx/widget-react
 
+## 4.0.56
+
+### Patch Changes
+
+- added translations for the tooltips
+- Updated dependencies
+  - @opencx/widget-core@4.0.56
+  - @opencx/widget-react-headless@4.0.56
+
 ## 4.0.55
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencx/widget-react",
   "private": false,
-  "version": "4.0.55",
+  "version": "4.0.56",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/react/src/screens/chat/ChatFooter.tsx
+++ b/packages/react/src/screens/chat/ChatFooter.tsx
@@ -51,6 +51,7 @@ function FileDisplay({
   file: FileWithProgress;
   onCancel: () => void;
 }) {
+  const { t } = useTranslation();
   const [fileContent, setFileContent] = useState<string | ArrayBuffer | null>(
     null,
   );
@@ -109,7 +110,9 @@ function FileDisplay({
       side="bottom"
       content={
         status === 'error' ? (
-          <span className="text-destructive">Failed to upload: {error}</span>
+          <span className="text-destructive">
+            {t('failed_to_upload')} {error}
+          </span>
         ) : (
           file.name
         )
@@ -315,7 +318,7 @@ function ChatInput() {
           <Tooltippy
             side="top"
             align="start"
-            content="attach images, PDFs, or spreadsheets (maximum size 5mb)"
+            content={t('attach_file_tooltip')}
           >
             <Button
               onClick={dropzone__openFileSelect}
@@ -339,7 +342,7 @@ function ChatInput() {
             </Button>
           </Tooltippy>
 
-          <Tooltippy content="send message" side="top" align="end">
+          <Tooltippy content={t('send_message')} side="top" align="end">
             <Button
               size="fit"
               onClick={handleSubmit}


### PR DESCRIPTION
The chat footer tooltips ("send message", the attach hint, and the upload-error label) were hardcoded English and ignored the widget's `language` config. They now render translated content through the same `useTranslation()` path as the rest of the widget.

## Changes
- Add `send_message`, `attach_file_tooltip`, `failed_to_upload` to `TranslationInterface` — the type gate that forces every language file to supply them.
- Wire the three `ChatFooter` tooltips to `t(...)`; `FileDisplay` gains the `useTranslation()` hook. The upload error value stays dynamic (`{t('failed_to_upload')} {error}`).
- Translate all 38 supported languages.

Type-check is clean for the touched packages (the two pre-existing `sessions/index.tsx` errors are unrelated).