### PR TITLE
Apply saved live appearance in installed widgets

### DIFF
--- a/.changeset/live-widget-appearance.md
+++ b/.changeset/live-widget-appearance.md
@@ -1,0 +1,12 @@
+---
+'@opencx/widget-core': minor
+'@opencx/widget-react-headless': minor
+'@opencx/widget-react': minor
+'@opencx/widget': minor
+---
+
+Load the organization's saved live appearance during widget initialization.
+Presentation fields are allowlisted and deep-merged while authentication,
+visitor identity, request configuration, routing, hooks, and other embed-owned
+behavior remain unchanged. Set `disableLiveAppearance` for code-owned previews
+that must keep their inline presentation options.

--- a/packages/core/src/__tests__/context/widget/live-appearance.spec.ts
+++ b/packages/core/src/__tests__/context/widget/live-appearance.spec.ts
@@ -295,6 +295,50 @@ suite('live appearance', () => {
     expect(Object.prototype).not.toHaveProperty('polluted');
   });
 
+  test('iteratively merges deeply nested legacy presentation data', async () => {
+    const inlineLegacy: Record<string, unknown> = {};
+    const savedLegacy: Record<string, unknown> = {};
+    let inlineCursor = inlineLegacy;
+    let savedCursor = savedLegacy;
+    for (let depth = 0; depth < 20_000; depth += 1) {
+      const inlineChild: Record<string, unknown> = {};
+      const savedChild: Record<string, unknown> = {};
+      inlineCursor.next = inlineChild;
+      savedCursor.next = savedChild;
+      inlineCursor = inlineChild;
+      savedCursor = savedChild;
+    }
+    inlineCursor.value = 'inline';
+    savedCursor.value = 'saved';
+    const inlineConfig = {
+      token: 'inline-token',
+      theme: { primaryColor: '#111111', legacy: inlineLegacy },
+    };
+    const data = {
+      ...EXTERNAL_CONFIG,
+      appearance: { theme: { primaryColor: '#2255ff', legacy: savedLegacy } },
+    };
+    vi.mocked(
+      ApiCaller.prototype.getExternalWidgetConfig,
+    ).mockResolvedValueOnce({
+      response: new Response(),
+      data,
+    });
+
+    const widgetCtx = await WidgetCtx.initialize({ config: inlineConfig });
+    const resolvedTheme = widgetCtx.config.theme;
+    if (!resolvedTheme) throw new Error('Expected a resolved theme');
+    let resolvedCursor: unknown = Reflect.get(resolvedTheme, 'legacy');
+    for (let depth = 0; depth < 20_000; depth += 1) {
+      if (typeof resolvedCursor !== 'object' || resolvedCursor === null)
+        throw new Error(`Missing legacy value at depth ${depth}`);
+      resolvedCursor = Reflect.get(resolvedCursor, 'next');
+    }
+    if (typeof resolvedCursor !== 'object' || resolvedCursor === null)
+      throw new Error('Missing final legacy value');
+    expect(Reflect.get(resolvedCursor, 'value')).toBe('saved');
+  });
+
   test('skips only live appearance when the inline config opts out', async () => {
     const inlineConfig = {
       token: 'inline-token',

--- a/packages/core/src/__tests__/context/widget/live-appearance.spec.ts
+++ b/packages/core/src/__tests__/context/widget/live-appearance.spec.ts
@@ -1,0 +1,325 @@
+import '../../api-caller.mock';
+
+import { ApiCaller } from '../../../api/api-caller';
+import { WidgetCtx } from '../../../context/widget.ctx';
+import type { WidgetConfig } from '../../../types/widget-config';
+
+const EXTERNAL_CONFIG = {
+  org: { id: 'org-id', name: 'Org' },
+  sessionsPollingIntervalSeconds: 60,
+  sessionPollingIntervalSeconds: 10,
+  modes: [],
+  appearance: null,
+};
+
+suite('live appearance', () => {
+  test('deeply applies appearance without mutating inline presentation options', async () => {
+    const inlineConfig = {
+      token: 'inline-token',
+      theme: {
+        primaryColor: '#111111',
+        screens: {
+          chat: { width: '700px', height: '640px' },
+        },
+      },
+    };
+    const data = {
+      ...EXTERNAL_CONFIG,
+      appearance: {
+        theme: {
+          primaryColor: '#2255ff',
+          widgetContentContainer: { borderRadius: '20px' },
+        },
+      },
+    };
+    vi.mocked(
+      ApiCaller.prototype.getExternalWidgetConfig,
+    ).mockResolvedValueOnce({
+      response: new Response(),
+      data,
+    });
+
+    const widgetCtx = await WidgetCtx.initialize({ config: inlineConfig });
+
+    expect(widgetCtx.config.theme).toEqual({
+      primaryColor: '#2255ff',
+      screens: {
+        chat: { width: '700px', height: '640px' },
+      },
+      widgetContentContainer: { borderRadius: '20px' },
+    });
+    expect(inlineConfig.theme).toEqual({
+      primaryColor: '#111111',
+      screens: {
+        chat: { width: '700px', height: '640px' },
+      },
+    });
+  });
+
+  test('only lets saved presentation fields override embed-owned behavior', async () => {
+    const onNavigateToChat = vi.fn();
+    const onSessionCreated = vi.fn();
+    const onMessageReceived = vi.fn();
+    const inlineConfig: WidgetConfig = {
+      token: 'inline-token',
+      apiUrl: 'https://customer-proxy.example.com',
+      language: 'fr',
+      isOpen: true,
+      openAfterNSeconds: 5,
+      collectUserData: true,
+      prefillUserData: { name: 'Inline visitor' },
+      extraDataCollectionFields: ['Account ID'],
+      user: { token: 'visitor-token', externalId: 'workspace-id' },
+      router: { chatScreenOnly: true },
+      hooks: { onNavigateToChat, onSessionCreated, onMessageReceived },
+      oneOpenSessionAllowed: true,
+      headers: { 'x-customer': 'inline' },
+      queryParams: { account: '123' },
+      bodyProperties: { plan: 'pro' },
+      context: { page: 'checkout' },
+      messageCustomData: { source: 'widget' },
+      sessionCustomData: { source: 'website' },
+      inline: true,
+      disableLiveAppearance: false,
+      disableSendingWhenAwaitingAIReply: false,
+      cssOverrides: '.inline { color: red; }',
+    };
+    const data = {
+      ...EXTERNAL_CONFIG,
+      appearance: {
+        token: 'server-token',
+        language: 'de',
+        isOpen: false,
+        openAfterNSeconds: 60,
+        collectUserData: false,
+        prefillUserData: { name: 'Server visitor' },
+        extraDataCollectionFields: ['Server field'],
+        user: { token: 'server-visitor-token' },
+        router: { chatScreenOnly: false },
+        hooks: {},
+        oneOpenSessionAllowed: false,
+        headers: { authorization: 'server' },
+        queryParams: { account: 'server' },
+        bodyProperties: { plan: 'server' },
+        context: { page: 'server' },
+        messageCustomData: { source: 'server' },
+        sessionCustomData: { source: 'server' },
+        inline: false,
+        disableLiveAppearance: true,
+        disableSendingWhenAwaitingAIReply: true,
+        apiUrl: 'https://attacker.example.com',
+        cssOverrides: '.server { color: blue; }',
+      },
+    };
+    vi.mocked(
+      ApiCaller.prototype.getExternalWidgetConfig,
+    ).mockResolvedValueOnce({
+      response: new Response(),
+      data,
+    });
+
+    const widgetCtx = await WidgetCtx.initialize({ config: inlineConfig });
+
+    expect(widgetCtx.config).toMatchObject({
+      token: 'inline-token',
+      apiUrl: 'https://customer-proxy.example.com',
+      language: 'fr',
+      isOpen: true,
+      openAfterNSeconds: 5,
+      collectUserData: true,
+      prefillUserData: { name: 'Inline visitor' },
+      extraDataCollectionFields: ['Account ID'],
+      user: { token: 'visitor-token', externalId: 'workspace-id' },
+      router: { chatScreenOnly: true },
+      hooks: { onNavigateToChat, onSessionCreated, onMessageReceived },
+      oneOpenSessionAllowed: true,
+      headers: { 'x-customer': 'inline' },
+      queryParams: { account: '123' },
+      bodyProperties: { plan: 'pro' },
+      context: { page: 'checkout' },
+      messageCustomData: { source: 'widget' },
+      sessionCustomData: { source: 'website' },
+      inline: true,
+      disableLiveAppearance: false,
+      disableSendingWhenAwaitingAIReply: false,
+      cssOverrides: '.server { color: blue; }',
+    });
+  });
+
+  test('applies every supported presentation field and replaces arrays', async () => {
+    const inlineConfig: WidgetConfig = {
+      token: 'inline-token',
+      bot: { name: 'Inline bot', avatarUrl: '/inline-bot.png' },
+      humanAgent: { name: 'Inline agent', avatarUrl: '/inline-agent.png' },
+      disableTooltips: false,
+      assets: {
+        organizationLogo: '/inline-logo.png',
+        widgetTrigger: { openIcon: '/inline-open.svg' },
+      },
+      chatBannerItems: [{ message: 'Inline banner' }],
+      initialMessages: ['Inline greeting'],
+      advancedInitialMessages: [{ message: 'Inline advanced greeting' }],
+      initialQuestions: ['Inline question'],
+      initialQuestionsPosition: 'above-chat-input',
+      chatFooterItems: [{ message: 'Inline footer' }],
+      textContent: {
+        welcomeScreen: {
+          title: 'Inline title',
+          description: 'Inline description',
+        },
+      },
+      anchorTarget: '_top',
+      thisWasHelpfulOrNot: { enabled: false },
+      timestamps: { perMessageGroup: { enabled: false } },
+      accessibility: { widgetTriggerButton: { label: 'Inline label' } },
+    };
+    const data = {
+      ...EXTERNAL_CONFIG,
+      appearance: {
+        bot: { name: 'Saved bot' },
+        humanAgent: { name: 'Saved agent' },
+        disableTooltips: true,
+        assets: {
+          organizationLogo: '/saved-logo.png',
+          widgetTrigger: { closeIcon: '/saved-close.svg' },
+        },
+        chatBannerItems: [{ message: 'Saved banner', persistent: true }],
+        initialMessages: ['Saved greeting'],
+        advancedInitialMessages: [
+          { message: 'Saved advanced greeting', persistent: true },
+        ],
+        initialQuestions: ['Saved question'],
+        initialQuestionsPosition: 'below-initial-messages',
+        chatFooterItems: [
+          { message: 'Saved footer', showWhenSessionIsOpen: false },
+        ],
+        textContent: {
+          welcomeScreen: { title: 'Saved title' },
+          chatScreen: { headerTitle: 'Saved chat' },
+        },
+        anchorTarget: '_blank',
+        thisWasHelpfulOrNot: { enabled: true },
+        timestamps: { perMessageGroup: { enabled: true } },
+        accessibility: { widgetTriggerButton: { label: 'Saved label' } },
+      },
+    };
+    vi.mocked(
+      ApiCaller.prototype.getExternalWidgetConfig,
+    ).mockResolvedValueOnce({
+      response: new Response(),
+      data,
+    });
+
+    const widgetCtx = await WidgetCtx.initialize({ config: inlineConfig });
+
+    expect(widgetCtx.config).toMatchObject({
+      bot: { name: 'Saved bot', avatarUrl: '/inline-bot.png' },
+      humanAgent: { name: 'Saved agent', avatarUrl: '/inline-agent.png' },
+      disableTooltips: true,
+      assets: {
+        organizationLogo: '/saved-logo.png',
+        widgetTrigger: {
+          openIcon: '/inline-open.svg',
+          closeIcon: '/saved-close.svg',
+        },
+      },
+      chatBannerItems: [{ message: 'Saved banner', persistent: true }],
+      initialMessages: ['Saved greeting'],
+      advancedInitialMessages: [
+        { message: 'Saved advanced greeting', persistent: true },
+      ],
+      initialQuestions: ['Saved question'],
+      initialQuestionsPosition: 'below-initial-messages',
+      chatFooterItems: [
+        { message: 'Saved footer', showWhenSessionIsOpen: false },
+      ],
+      textContent: {
+        welcomeScreen: {
+          title: 'Saved title',
+          description: 'Inline description',
+        },
+        chatScreen: { headerTitle: 'Saved chat' },
+      },
+      anchorTarget: '_blank',
+      thisWasHelpfulOrNot: { enabled: true },
+      timestamps: { perMessageGroup: { enabled: true } },
+      accessibility: { widgetTriggerButton: { label: 'Saved label' } },
+    });
+  });
+
+  test('blocks prototype-pollution keys at every merged object level', async () => {
+    const inlineConfig: WidgetConfig = {
+      token: 'inline-token',
+      theme: {
+        primaryColor: '#111111',
+        screens: { chat: { width: '700px' } },
+      },
+    };
+    const pollutionKeys = {
+      ['__proto__']: { polluted: true },
+      constructor: { polluted: true },
+      prototype: { polluted: true },
+    };
+    const data = {
+      ...EXTERNAL_CONFIG,
+      appearance: {
+        theme: {
+          primaryColor: '#2255ff',
+          ...pollutionKeys,
+          screens: pollutionKeys,
+        },
+      },
+    };
+    vi.mocked(
+      ApiCaller.prototype.getExternalWidgetConfig,
+    ).mockResolvedValueOnce({
+      response: new Response(),
+      data,
+    });
+
+    const widgetCtx = await WidgetCtx.initialize({ config: inlineConfig });
+    const resolvedTheme = widgetCtx.config.theme;
+    const resolvedScreens = resolvedTheme?.screens;
+
+    expect(resolvedTheme?.primaryColor).toBe('#2255ff');
+    expect(Object.getPrototypeOf(resolvedTheme)).toBe(Object.prototype);
+    expect(Object.getPrototypeOf(resolvedScreens)).toBe(Object.prototype);
+    for (const key of ['constructor', 'prototype']) {
+      expect(Object.prototype.hasOwnProperty.call(resolvedTheme, key)).toBe(
+        false,
+      );
+      expect(Object.prototype.hasOwnProperty.call(resolvedScreens, key)).toBe(
+        false,
+      );
+    }
+    expect(Object.prototype).not.toHaveProperty('polluted');
+  });
+
+  test('skips only live appearance when the inline config opts out', async () => {
+    const inlineConfig = {
+      token: 'inline-token',
+      disableLiveAppearance: true,
+      theme: { primaryColor: '#111111' },
+    };
+    const data = {
+      ...EXTERNAL_CONFIG,
+      org: { id: 'saved-org-id', name: 'Saved org' },
+      modes: [{ id: 'saved-mode-id', name: 'Saved mode', slug: null }],
+      appearance: { theme: { primaryColor: '#2255ff' } },
+    };
+    vi.mocked(
+      ApiCaller.prototype.getExternalWidgetConfig,
+    ).mockResolvedValueOnce({
+      response: new Response(),
+      data,
+    });
+
+    const widgetCtx = await WidgetCtx.initialize({ config: inlineConfig });
+
+    expect(widgetCtx.config.theme).toEqual({ primaryColor: '#111111' });
+    expect(widgetCtx.org).toEqual({ id: 'saved-org-id', name: 'Saved org' });
+    expect(widgetCtx.modes).toEqual([
+      { id: 'saved-mode-id', name: 'Saved mode', slug: null },
+    ]);
+  });
+});

--- a/packages/core/src/__tests__/test-utils.ts
+++ b/packages/core/src/__tests__/test-utils.ts
@@ -115,6 +115,7 @@ export const TestUtils = {
               sessionPollingIntervalSeconds: 10,
               modes: [],
               ...returnValue?.data,
+              appearance: returnValue?.data?.appearance ?? null,
             },
           });
       },

--- a/packages/core/src/api/schema.ts
+++ b/packages/core/src/api/schema.ts
@@ -754,6 +754,25 @@ export interface components {
         name: string;
         slug?: string | null;
       }[];
+      appearance: {
+        bot?: unknown;
+        humanAgent?: unknown;
+        cssOverrides?: unknown;
+        theme?: unknown;
+        disableTooltips?: unknown;
+        assets?: unknown;
+        chatBannerItems?: unknown;
+        initialMessages?: unknown;
+        advancedInitialMessages?: unknown;
+        initialQuestions?: unknown;
+        initialQuestionsPosition?: unknown;
+        chatFooterItems?: unknown;
+        textContent?: unknown;
+        anchorTarget?: unknown;
+        thisWasHelpfulOrNot?: unknown;
+        timestamps?: unknown;
+        accessibility?: unknown;
+      } | null;
     };
     WidgetPreludeDto: {
       org: {
@@ -767,6 +786,25 @@ export interface components {
         name: string;
         slug?: string | null;
       }[];
+      appearance: {
+        bot?: unknown;
+        humanAgent?: unknown;
+        cssOverrides?: unknown;
+        theme?: unknown;
+        disableTooltips?: unknown;
+        assets?: unknown;
+        chatBannerItems?: unknown;
+        initialMessages?: unknown;
+        advancedInitialMessages?: unknown;
+        initialQuestions?: unknown;
+        initialQuestionsPosition?: unknown;
+        chatFooterItems?: unknown;
+        textContent?: unknown;
+        anchorTarget?: unknown;
+        thisWasHelpfulOrNot?: unknown;
+        timestamps?: unknown;
+        accessibility?: unknown;
+      } | null;
     };
     WidgetContactTokenResponseDto: {
       /** @description The JWT token to use for further requests */

--- a/packages/core/src/context/widget.ctx.ts
+++ b/packages/core/src/context/widget.ctx.ts
@@ -1,7 +1,10 @@
 import { ApiCaller } from '../api/api-caller';
 import type { ModeDto } from '../types/dtos';
 import type { ExternalStorage } from '../types/external-storage';
-import type { WidgetConfig } from '../types/widget-config';
+import {
+  widgetAppearanceKeys,
+  type WidgetConfig,
+} from '../types/widget-config';
 import { ActiveSessionPollingCtx } from './active-session-polling.ctx';
 import { ContactCtx } from './contact.ctx';
 import { CsatCtx } from './csat.ctx';
@@ -9,6 +12,12 @@ import { MessageCtx } from './message.ctx';
 import { RouterCtx } from './router.ctx';
 import { SessionCtx } from './session.ctx';
 import { StorageCtx } from './storage.ctx';
+
+const blockedAppearanceObjectKeys = new Set([
+  '__proto__',
+  'constructor',
+  'prototype',
+]);
 
 export class WidgetCtx {
   public config: WidgetConfig;
@@ -31,6 +40,32 @@ export class WidgetCtx {
     sessions: number;
   } | null = null;
   private activeSessionPollingCtx: ActiveSessionPollingCtx;
+
+  private static mergeAppearanceValue(
+    base: unknown,
+    appearance: unknown,
+  ): unknown {
+    if (
+      typeof base !== 'object' ||
+      base === null ||
+      Array.isArray(base) ||
+      typeof appearance !== 'object' ||
+      appearance === null ||
+      Array.isArray(appearance)
+    ) {
+      return appearance;
+    }
+
+    const merged: Record<string, unknown> = { ...base };
+    for (const [key, value] of Object.entries(appearance)) {
+      if (blockedAppearanceObjectKeys.has(key)) continue;
+      merged[key] = WidgetCtx.mergeAppearanceValue(
+        Reflect.get(base, key),
+        value,
+      );
+    }
+    return merged;
+  }
 
   private constructor({
     config,
@@ -122,8 +157,20 @@ export class WidgetCtx {
       sessions: externalConfig.data?.sessionsPollingIntervalSeconds || 60,
     };
 
+    const appearance = config.disableLiveAppearance
+      ? null
+      : externalConfig.data.appearance;
+    const resolvedConfig = appearance ? { ...config } : config;
+    for (const key of widgetAppearanceKeys) {
+      if (appearance && Object.prototype.hasOwnProperty.call(appearance, key)) {
+        Object.assign(resolvedConfig, {
+          [key]: this.mergeAppearanceValue(config[key], appearance[key]),
+        });
+      }
+    }
+
     return new WidgetCtx({
-      config,
+      config: resolvedConfig,
       storage,
       modes: externalConfig.data?.modes || [],
       org: {

--- a/packages/core/src/context/widget.ctx.ts
+++ b/packages/core/src/context/widget.ctx.ts
@@ -57,12 +57,34 @@ export class WidgetCtx {
     }
 
     const merged: Record<string, unknown> = { ...base };
-    for (const [key, value] of Object.entries(appearance)) {
-      if (blockedAppearanceObjectKeys.has(key)) continue;
-      merged[key] = WidgetCtx.mergeAppearanceValue(
-        Reflect.get(base, key),
-        value,
-      );
+    const pending: Array<{
+      base: object;
+      appearance: object;
+      target: Record<string, unknown>;
+    }> = [{ base, appearance, target: merged }];
+
+    while (pending.length > 0) {
+      const current = pending.pop();
+      if (!current) continue;
+
+      for (const [key, value] of Object.entries(current.appearance)) {
+        if (blockedAppearanceObjectKeys.has(key)) continue;
+        const baseValue = Reflect.get(current.base, key);
+        if (
+          typeof baseValue === 'object' &&
+          baseValue !== null &&
+          !Array.isArray(baseValue) &&
+          typeof value === 'object' &&
+          value !== null &&
+          !Array.isArray(value)
+        ) {
+          const child: Record<string, unknown> = { ...baseValue };
+          current.target[key] = child;
+          pending.push({ base: baseValue, appearance: value, target: child });
+        } else {
+          current.target[key] = value;
+        }
+      }
     }
     return merged;
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,6 +32,7 @@ export type {
   ModeComponentProps,
   CustomComponent,
   CustomComponentProps,
+  WidgetAppearance,
 } from './types/widget-config';
 export type { ExternalStorage } from './types/external-storage';
 export type { OpenCxComponentNameU } from './types/component-name';

--- a/packages/core/src/types/widget-config.ts
+++ b/packages/core/src/types/widget-config.ts
@@ -285,6 +285,13 @@ export interface WidgetConfig {
   openAfterNSeconds?: number;
 
   /**
+   * Prevent saved live appearance from overriding inline presentation options.
+   * Organization, mode, and polling settings are still loaded from the server.
+   * @default false
+   */
+  disableLiveAppearance?: boolean;
+
+  /**
    * A custom vanilla stylesheet to override the default styles. See {@link OpenCxComponentNameU} for available component names.
    *
    * @example Overriding a component's styles
@@ -672,3 +679,27 @@ export interface WidgetConfig {
    */
   apiUrl?: string;
 }
+
+export const widgetAppearanceKeys = [
+  'bot',
+  'humanAgent',
+  'cssOverrides',
+  'theme',
+  'disableTooltips',
+  'assets',
+  'chatBannerItems',
+  'initialMessages',
+  'advancedInitialMessages',
+  'initialQuestions',
+  'initialQuestionsPosition',
+  'chatFooterItems',
+  'textContent',
+  'anchorTarget',
+  'thisWasHelpfulOrNot',
+  'timestamps',
+  'accessibility',
+] as const satisfies ReadonlyArray<keyof WidgetConfig>;
+
+export type WidgetAppearance = Partial<
+  Pick<WidgetConfig, (typeof widgetAppearanceKeys)[number]>
+>;

--- a/packages/react-headless/src/WidgetProvider.tsx
+++ b/packages/react-headless/src/WidgetProvider.tsx
@@ -74,7 +74,7 @@ export function WidgetProvider({
     <context.Provider
       value={{
         widgetCtx,
-        config,
+        config: widgetCtx.config,
         components,
         componentStore,
         version,

--- a/packages/react-headless/src/__tests__/WidgetProvider.spec.tsx
+++ b/packages/react-headless/src/__tests__/WidgetProvider.spec.tsx
@@ -1,0 +1,73 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import type { WidgetConfig } from '@opencx/widget-core';
+import { WidgetProvider, useWidget } from '../WidgetProvider';
+
+test('provides the config resolved by WidgetCtx', async () => {
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  const inlineConfig: WidgetConfig = {
+    token: 'inline-token',
+    theme: {
+      primaryColor: '#111111',
+      screens: { chat: { width: '700px' } },
+    },
+  };
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            org: { id: 'org-id', name: 'Org' },
+            sessionsPollingIntervalSeconds: 60,
+            sessionPollingIntervalSeconds: 10,
+            modes: [],
+            appearance: {
+              theme: {
+                primaryColor: '#2255ff',
+                widgetContentContainer: { borderRadius: '20px' },
+              },
+            },
+          }),
+          { headers: { 'Content-Type': 'application/json' } },
+        ),
+    ),
+  );
+
+  let providedConfig: WidgetConfig | null = null;
+  function ConfigProbe() {
+    providedConfig = useWidget().config;
+    return null;
+  }
+
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(
+      <WidgetProvider
+        options={inlineConfig}
+        components={[{ key: 'fallback', component: () => null }]}
+      >
+        <ConfigProbe />
+      </WidgetProvider>,
+    );
+  });
+  await act(async () => {
+    await vi.waitUntil(() => providedConfig !== null);
+  });
+
+  expect(providedConfig).toMatchObject({
+    token: 'inline-token',
+    theme: {
+      primaryColor: '#2255ff',
+      screens: { chat: { width: '700px' } },
+      widgetContentContainer: { borderRadius: '20px' },
+    },
+  });
+
+  await act(async () => root.unmount());
+  container.remove();
+  vi.unstubAllGlobals();
+});


### PR DESCRIPTION
Loads the organization saved live appearance through an explicit presentation allowlist, preserves embed-owned behavior, adds disableLiveAppearance for pinned snapshots, and merges deep legacy data iteratively. Verified with 54 core tests, headless and React suites, package builds, and a real five-state installed-widget browser test. Includes a minor changeset; the dependent OpenCX PR should bump from 4.0.59 after this release is published.