### PR TITLE
fix rtl widget position: open the chat box on the trigger's side

### DIFF
--- a/.changeset/rtl-popover-follows-trigger-side.md
+++ b/.changeset/rtl-popover-follows-trigger-side.md
@@ -1,0 +1,6 @@
+---
+'@opencx/widget-react': patch
+'@opencx/widget': patch
+---
+
+fix: open the chat box on the same side as the trigger button when `theme.widgetTrigger.offset` explicitly pins a side (e.g. `{ right: 20 }` on an RTL page). Previously the trigger honored the explicit offset while the popover anchor and alignment followed the host document direction, so the box opened on the opposite side.

--- a/packages/react/src/WidgetPopoverAnchor.tsx
+++ b/packages/react/src/WidgetPopoverAnchor.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
 import * as PopoverPrimitive from '@radix-ui/react-popover';
-import { useDocumentDir } from '@opencx/widget-react-headless';
+import { useTheme } from './hooks/useTheme';
 
 export function WidgetPopoverAnchor() {
-  const { dir } = useDocumentDir();
+  const { triggerSide } = useTheme();
 
   return (
     <PopoverPrimitive.Anchor
       style={{
         position: 'fixed',
         bottom: 0,
-        right: dir === 'ltr' ? 0 : undefined,
-        left: dir === 'rtl' ? 0 : undefined,
+        right: triggerSide === 'right' ? 0 : undefined,
+        left: triggerSide === 'left' ? 0 : undefined,
       }}
     />
   );

--- a/packages/react/src/WidgetPopoverContent.tsx
+++ b/packages/react/src/WidgetPopoverContent.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import styles from '../index.css?inline.css';
 import {
   useConfig,
+  useDocumentDir,
   useWidget,
   useWidgetTrigger,
 } from '@opencx/widget-react-headless';
@@ -123,7 +124,17 @@ export function WidgetContent() {
 }
 
 export function WidgetPopoverContent() {
-  const { theme } = useTheme();
+  const { theme, triggerSide } = useTheme();
+  const { dir: hostDocumentDir } = useDocumentDir();
+
+  // Radix/floating-ui resolves `align` logically against the floating element's
+  // computed direction (inherited from the host page via the portal): on an RTL
+  // host, 'end' means the physical LEFT edge. Map the resolved physical side
+  // back to the logical align so the box always opens on the trigger's side.
+  const align =
+    (hostDocumentDir === 'rtl' ? triggerSide === 'left' : triggerSide === 'right')
+      ? 'end'
+      : 'start';
 
   return (
     <PopoverPrimitive.Content
@@ -134,7 +145,7 @@ export function WidgetPopoverContent() {
         fontSize: '16px',
       }}
       side="top"
-      align="end"
+      align={align}
       aria-modal="false"
       aria-label="Support chat"
       sideOffset={theme.widgetContentContainer.offset.side}

--- a/packages/react/src/hooks/useTheme.ts
+++ b/packages/react/src/hooks/useTheme.ts
@@ -3,6 +3,7 @@ import tc from 'tinycolor2';
 import { isExhaustive, type WidgetConfig } from '@opencx/widget-core';
 import { useConfig, useDocumentDir } from '@opencx/widget-react-headless';
 import { WOBBLE_MAX_MOVEMENT_PIXELS } from '../components/lib/wobble';
+import { resolveTriggerSide } from '../utils/resolve-trigger-side';
 import { useIsSmallScreen } from './useIsSmallScreen';
 
 type DeepRequired<T> = {
@@ -34,14 +35,18 @@ export function useTheme() {
     return withInlineDefault(withSmallScreenDefault(target, v));
   };
 
+  const triggerSide = resolveTriggerSide(theme?.widgetTrigger?.offset, dir);
+
   const widgetTrigger = {
     zIndex: theme?.widgetTrigger?.zIndex ?? 10_000_000,
     offset: {
       bottom: theme?.widgetTrigger?.offset?.bottom ?? 20,
       right:
-        theme?.widgetTrigger?.offset?.right ?? (dir === 'ltr' ? 20 : 'initial'),
+        theme?.widgetTrigger?.offset?.right ??
+        (triggerSide === 'right' ? 20 : 'initial'),
       left:
-        theme?.widgetTrigger?.offset?.left ?? (dir === 'rtl' ? 20 : 'initial'),
+        theme?.widgetTrigger?.offset?.left ??
+        (triggerSide === 'left' ? 20 : 'initial'),
     },
     size: {
       button: theme?.widgetTrigger?.size?.button ?? 48,
@@ -51,7 +56,9 @@ export function useTheme() {
 
   const triggerOffset = (() => {
     const v =
-      dir === 'ltr' ? widgetTrigger.offset.right : widgetTrigger.offset.left;
+      triggerSide === 'right'
+        ? widgetTrigger.offset.right
+        : widgetTrigger.offset.left;
     if (typeof v !== 'number') return 0;
     return v;
   })();
@@ -169,6 +176,7 @@ export function useTheme() {
 
   return {
     theme: themeWithFallbacks,
+    triggerSide,
     computed,
     cssVars: cssVars({
       palette: themeWithFallbacks.palette,

--- a/packages/react/src/utils/__tests__/resolve-trigger-side.spec.ts
+++ b/packages/react/src/utils/__tests__/resolve-trigger-side.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { resolveTriggerSide } from '../resolve-trigger-side';
+
+describe(resolveTriggerSide.name, () => {
+  it('defaults to right on LTR when no offset config', () => {
+    expect(resolveTriggerSide(undefined, 'ltr')).toBe('right');
+    expect(resolveTriggerSide({}, 'ltr')).toBe('right');
+  });
+
+  it('defaults to left on RTL when no offset config', () => {
+    expect(resolveTriggerSide(undefined, 'rtl')).toBe('left');
+    expect(resolveTriggerSide({}, 'rtl')).toBe('left');
+  });
+
+  it('explicit numeric right wins over RTL direction', () => {
+    expect(resolveTriggerSide({ right: 20 }, 'rtl')).toBe('right');
+    expect(resolveTriggerSide({ right: 20, left: 'initial' }, 'rtl')).toBe(
+      'right',
+    );
+    expect(resolveTriggerSide({ right: 0 }, 'rtl')).toBe('right');
+  });
+
+  it('explicit numeric left wins over LTR direction', () => {
+    expect(resolveTriggerSide({ left: 20 }, 'ltr')).toBe('left');
+    expect(resolveTriggerSide({ left: 20, right: 'initial' }, 'ltr')).toBe(
+      'left',
+    );
+    expect(resolveTriggerSide({ left: 0 }, 'ltr')).toBe('left');
+  });
+
+  it('explicit numeric offset on the direction-default side keeps that side', () => {
+    expect(resolveTriggerSide({ right: 32 }, 'ltr')).toBe('right');
+    expect(resolveTriggerSide({ left: 32 }, 'rtl')).toBe('left');
+  });
+
+  it('falls back to direction default when both sides are numeric (ambiguous)', () => {
+    expect(resolveTriggerSide({ right: 20, left: 20 }, 'ltr')).toBe('right');
+    expect(resolveTriggerSide({ right: 20, left: 20 }, 'rtl')).toBe('left');
+  });
+
+  it("treats 'initial' as not-a-side, falling back to direction default", () => {
+    expect(resolveTriggerSide({ right: 'initial' }, 'ltr')).toBe('right');
+    expect(resolveTriggerSide({ right: 'initial' }, 'rtl')).toBe('left');
+    expect(resolveTriggerSide({ left: 'initial' }, 'rtl')).toBe('left');
+    expect(
+      resolveTriggerSide({ right: 'initial', left: 'initial' }, 'rtl'),
+    ).toBe('left');
+  });
+
+  it('only bottom offset configured falls back to direction default', () => {
+    expect(resolveTriggerSide({ bottom: 40 }, 'ltr')).toBe('right');
+    expect(resolveTriggerSide({ bottom: 40 }, 'rtl')).toBe('left');
+  });
+
+  it('unknown direction values behave as LTR', () => {
+    expect(resolveTriggerSide(undefined, '')).toBe('right');
+    expect(resolveTriggerSide(undefined, 'auto')).toBe('right');
+  });
+});

--- a/packages/react/src/utils/resolve-trigger-side.ts
+++ b/packages/react/src/utils/resolve-trigger-side.ts
@@ -1,0 +1,27 @@
+import type { WidgetConfig } from '@opencx/widget-core';
+
+type TriggerOffsetConfig = NonNullable<
+  NonNullable<NonNullable<WidgetConfig['theme']>['widgetTrigger']>['offset']
+>;
+
+export type TriggerSide = 'left' | 'right';
+
+/**
+ * Resolves which horizontal side the whole widget (trigger button, popover
+ * anchor, and content alignment) lives on.
+ *
+ * An explicit numeric offset in the user config wins over the host document
+ * direction, so `offset: { right: 20 }` pins the widget to the right even on
+ * an RTL page. When both or neither side is numeric, the host document
+ * direction decides (LTR → right, RTL → left).
+ */
+export function resolveTriggerSide(
+  offset: TriggerOffsetConfig | undefined,
+  dir: string,
+): TriggerSide {
+  const rightIsNumber = typeof offset?.right === 'number';
+  const leftIsNumber = typeof offset?.left === 'number';
+  if (rightIsNumber && !leftIsNumber) return 'right';
+  if (leftIsNumber && !rightIsNumber) return 'left';
+  return dir === 'rtl' ? 'left' : 'right';
+}


### PR DESCRIPTION
Fix the chat box opening on the opposite side of the trigger button when `theme.widgetTrigger.offset` explicitly pins a side on an RTL page (e.g. `{ right: 20, left: 'initial' }` with an Arabic host page).

## Root cause

The side was resolved from two different sources that can disagree:

- the trigger button applies the explicit `offset` config verbatim → icon bottom-right
- `WidgetPopoverAnchor` and the popover align math only looked at the host document direction → box bottom-left on `dir=rtl` pages

Additionally, Radix/floating-ui resolves `align="end"` *logically* against the floating element's computed direction (inherited from the host page through the portal), so on an RTL host `end` means the physical left edge.

## Fix

- new `resolveTriggerSide(offset, dir)`: an explicit numeric `right`/`left` offset wins over the host document direction; when both or neither side is numeric, the direction decides (LTR → right, RTL → left)
- the resolved side drives all three places consistently: side-aware offset defaults for the trigger, the popover anchor position, and the (rtl-aware) logical `align` mapping
- bonus: `offset: { right: 20 }` alone now pins the whole widget right on RTL pages — the `left: 'initial'` hack is no longer needed

## Before / after

RTL Arabic page + `offset: { right: 20, left: 'initial' }`:

| before | after |
| --- | --- |
| ![before](https://raw.githubusercontent.com/openchatai/widget/a9149075b15d83d0c99bb4592bb3299374ab1feb/before.png) | ![after](https://raw.githubusercontent.com/openchatai/widget/a9149075b15d83d0c99bb4592bb3299374ab1feb/after.png) |

No behavior change without explicit offsets:

| RTL defaults (still bottom-left) | LTR defaults (still bottom-right) |
| --- | --- |
| ![rtl-default](https://raw.githubusercontent.com/openchatai/widget/a9149075b15d83d0c99bb4592bb3299374ab1feb/rtl-default.png) | ![ltr-default](https://raw.githubusercontent.com/openchatai/widget/a9149075b15d83d0c99bb4592bb3299374ab1feb/ltr-default.png) |