### PR TITLE
chore(release): bump version to 4.0.60 and update changelogs

### DIFF
--- a/.changeset/rtl-popover-follows-trigger-side.md
+++ b/.changeset/rtl-popover-follows-trigger-side.md
@@ -1,6 +1,0 @@
----
-'@opencx/widget-react': patch
-'@opencx/widget': patch
----
-
-fix: open the chat box on the same side as the trigger button when `theme.widgetTrigger.offset` explicitly pins a side (e.g. `{ right: 20 }` on an RTL page). Previously the trigger honored the explicit offset while the popover anchor and alignment followed the host document direction, so the box opened on the opposite side.

--- a/packages/embed/CHANGELOG.md
+++ b/packages/embed/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @opencx/widget
 
+## 4.0.60
+
+### Patch Changes
+
+- addb7c4: fix: open the chat box on the same side as the trigger button when `theme.widgetTrigger.offset` explicitly pins a side (e.g. `{ right: 20 }` on an RTL page). Previously the trigger honored the explicit offset while the popover anchor and alignment followed the host document direction, so the box opened on the opposite side.
+
 ## 4.0.59
 
 ### Patch Changes

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencx/widget",
   "private": false,
-  "version": "4.0.59",
+  "version": "4.0.60",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @opencx/widget-react
 
+## 4.0.60
+
+### Patch Changes
+
+- addb7c4: fix: open the chat box on the same side as the trigger button when `theme.widgetTrigger.offset` explicitly pins a side (e.g. `{ right: 20 }` on an RTL page). Previously the trigger honored the explicit offset while the popover anchor and alignment followed the host document direction, so the box opened on the opposite side.
+
 ## 4.0.59
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencx/widget-react",
   "private": false,
-  "version": "4.0.59",
+  "version": "4.0.60",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- fix: open the chat box on the same side as the trigger button when `theme.widgetTrigger.offset` explicitly pins a side (e.g. `{ right: 20 }` on an RTL page). This ensures the popover aligns correctly with the trigger, addressing previous inconsistencies.