### PR TITLE
fix: hide inline images in the session list preview

### DIFF
--- a/packages/react/src/screens/sessions/index.tsx
+++ b/packages/react/src/screens/sessions/index.tsx
@@ -87,6 +87,9 @@ function SessionCard({
                 <MemoizedReactMarkdown
                   remarkPlugins={[remarkGfm]}
                   rehypePlugins={[rehypeRaw]}
+                  // A one-line text preview: an agent reply carrying inline
+                  // images (macro inline images) must not render them here.
+                  components={{ img: () => null }}
                   // Do not add `prose` styling for last message preview
                   className="line-clamp-1 overflow-hidden text-ellipsis text-xs text-muted-foreground"
                 >


### PR DESCRIPTION
Agent replies built from a macro with inline images (opencx OPEN-1243) carry `<img>` tags in the body. The session list preview renders the message through `rehypeRaw` inside a one-line clamp, so the image itself showed up in the row — drop `img` from that renderer.

| Before | After |
| --- | --- |
| <img width="480" alt="session list preview rendering the screenshot inside the row" src="https://github.com/user-attachments/assets/900c9c05-03df-4b49-8b5d-906139b6bb69" /> | <img width="480" alt="session list preview showing text only" src="https://github.com/user-attachments/assets/2e3df8fd-e982-4f4f-9380-3e02e77c9c02" /> |