### PR TITLE
Retire a cancelled CSAT survey and roll back refused ratings

### DIFF
--- a/.changeset/csat-request-cancelled.md
+++ b/.changeset/csat-request-cancelled.md
@@ -1,0 +1,8 @@
+---
+'@opencx/widget-core': patch
+'@opencx/widget-react-headless': patch
+'@opencx/widget-react': patch
+'@opencx/widget': patch
+---
+
+Retire a rating survey the moment it is withdrawn: the widget now reads the withdrawal event from the session, rolls back a rating the server refused instead of showing it as recorded, and exposes `isCsatCancelled` from `useCsat`.

--- a/.changeset/csat-request-cancelled.md
+++ b/.changeset/csat-request-cancelled.md
@@ -1,8 +1,0 @@
----
-'@opencx/widget-core': patch
-'@opencx/widget-react-headless': patch
-'@opencx/widget-react': patch
-'@opencx/widget': patch
----
-
-Retire a rating survey the moment it is withdrawn: the widget now reads the withdrawal event from the session, rolls back a rating the server refused instead of showing it as recorded, and exposes `isCsatCancelled` from `useCsat`.

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @opencx/widget-core
 
+## 4.0.63
+
+### Patch Changes
+
+- 2a7e3b3: Retire a rating survey the moment it is withdrawn: the widget now reads the withdrawal event from the session, rolls back a rating the server refused instead of showing it as recorded, and exposes `isCsatCancelled` from `useCsat`.
+
 ## 4.0.62
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencx/widget-core",
   "private": false,
-  "version": "4.0.62",
+  "version": "4.0.63",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/core/src/__tests__/context/csat/csat-request-cancelled-poll.spec.ts
+++ b/packages/core/src/__tests__/context/csat/csat-request-cancelled-poll.spec.ts
@@ -1,0 +1,85 @@
+import '../../api-caller.mock';
+
+import { ApiCaller } from '../../../api/api-caller';
+import { WidgetCtx } from '../../../context/widget.ctx';
+import type { MessageDto, SessionDto } from '../../../types/dtos';
+import { deriveCsatState } from '../../../utils/derive-csat-state';
+import { genUuid } from '../../../utils/uuid';
+import { TestUtils } from '../../test-utils';
+
+const makeSessionDto = (overrides: Partial<SessionDto> = {}): SessionDto => ({
+  id: genUuid(),
+  ticketNumber: 1,
+  title: null,
+  assignee: { kind: 'ai', name: null, avatarUrl: null },
+  channel: '',
+  createdAt: new Date().toISOString(),
+  isHandedOff: false,
+  isOpened: false,
+  isVerified: false,
+  lastMessage: '',
+  updatedAt: new Date().toISOString(),
+  modeId: null,
+  latestStateCheckpointPayload: null,
+  sessionAttributes: {},
+  customStatus: null,
+  ...overrides,
+});
+
+const systemHistoryItem = (
+  payload: MessageDto['systemMessagePayload'],
+  type: MessageDto['type'],
+): MessageDto => ({
+  publicId: genUuid(),
+  type,
+  content: { text: null },
+  sentAt: new Date().toISOString(),
+  attachments: null,
+  actionCalls: null,
+  sender: { kind: 'system', name: null, avatar: null },
+  systemMessagePayload: payload,
+});
+
+const requestedItem = () =>
+  systemHistoryItem({ type: 'csat_requested', payload: null }, 'csat_requested');
+const cancelledItem = () =>
+  systemHistoryItem(
+    { type: 'csat_request_cancelled', payload: null },
+    'csat_request_cancelled',
+  );
+
+const openSessionWithHistory = async (history: MessageDto[]) => {
+  const session = makeSessionDto();
+  TestUtils.mock.ApiCaller.pollSessionAndHistory(ApiCaller, {
+    data: { session, history },
+  });
+  const widgetCtx = await WidgetCtx.initialize({ config: { token: '' } });
+  widgetCtx.sessionCtx.sessionState.setPartial({ session });
+  await TestUtils.sleep(50);
+  return widgetCtx;
+};
+
+suite('csat_request_cancelled arriving through the session poll', () => {
+  it('maps to a SYSTEM message the survey state can fold over', async () => {
+    const widgetCtx = await openSessionWithHistory([requestedItem(), cancelledItem()]);
+
+    const messages = widgetCtx.messageCtx.state.get().messages;
+    expect(messages.map((m) => (m.type === 'SYSTEM' ? m.subtype : m.type))).toEqual([
+      'csat_requested',
+      'csat_request_cancelled',
+    ]);
+    expect(deriveCsatState(messages)).toMatchObject({
+      isCsatRequested: false,
+      isCsatCancelled: true,
+    });
+  });
+
+  it('positive control: the same poll without the cancel leaves the picker live', async () => {
+    const widgetCtx = await openSessionWithHistory([requestedItem()]);
+
+    expect(deriveCsatState(widgetCtx.messageCtx.state.get().messages)).toMatchObject({
+      isCsatRequested: true,
+      isCsatCancelled: false,
+    });
+  });
+});

--- a/packages/core/src/__tests__/context/csat/submit-csat.spec.ts
+++ b/packages/core/src/__tests__/context/csat/submit-csat.spec.ts
@@ -105,6 +105,49 @@ suite('CsatCtx.submitCsat', () => {
     });
   });
 
+  it('refused as request_cancelled, but a newer request landed mid-flight → no echo, new survey stays live', async () => {
+    let resolveSubmit: (value: {
+      response: Response;
+      data: { success: false; reason: 'request_cancelled' };
+    }) => void = () => {};
+    vi.mocked(ApiCaller.prototype.submitCsat).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSubmit = resolve;
+        }),
+    );
+    const widgetCtx = await widgetWithLiveSurvey();
+
+    const inFlight = widgetCtx.csatCtx.submitCsat({ score: 2 });
+    // The poll delivers the old request's cancel and a brand-new request
+    // while the submit is still awaiting its (refusing) response.
+    const oldCancel: WidgetSystemMessageU = {
+      id: genUuid(),
+      type: 'SYSTEM',
+      subtype: 'csat_request_cancelled',
+      timestamp: new Date().toISOString(),
+      data: { payload: undefined },
+    };
+    widgetCtx.messageCtx.state.setPartial({
+      messages: [...widgetCtx.messageCtx.state.get().messages, oldCancel, csatRequested()],
+    });
+    resolveSubmit({
+      response: new Response(),
+      data: { success: false, reason: 'request_cancelled' },
+    });
+    await inFlight;
+
+    expect(subtypes(widgetCtx)).toEqual([
+      'csat_requested',
+      'csat_request_cancelled',
+      'csat_requested',
+    ]);
+    expect(deriveCsatState(widgetCtx.messageCtx.state.get().messages)).toMatchObject({
+      isCsatRequested: true,
+      isCsatCancelled: false,
+    });
+  });
+
   it('refused as rescore_locked → rolls the submission back, survey stays as it was', async () => {
     TestUtils.mock.ApiCaller.submitCsat(ApiCaller, {
       data: { success: false, reason: 'rescore_locked' },

--- a/packages/core/src/__tests__/context/csat/submit-csat.spec.ts
+++ b/packages/core/src/__tests__/context/csat/submit-csat.spec.ts
@@ -1,0 +1,143 @@
+import '../../api-caller.mock';
+
+import { ApiCaller } from '../../../api/api-caller';
+import { WidgetCtx } from '../../../context/widget.ctx';
+import type { SessionDto } from '../../../types/dtos';
+import type { WidgetSystemMessageU } from '../../../types/messages';
+import { deriveCsatState } from '../../../utils/derive-csat-state';
+import { genUuid } from '../../../utils/uuid';
+import { TestUtils } from '../../test-utils';
+
+const makeSessionDto = (overrides: Partial<SessionDto> = {}): SessionDto => ({
+  id: genUuid(),
+  ticketNumber: 1,
+  title: null,
+  assignee: { kind: 'ai', name: null, avatarUrl: null },
+  channel: '',
+  createdAt: new Date().toISOString(),
+  isHandedOff: false,
+  isOpened: false,
+  isVerified: false,
+  lastMessage: '',
+  updatedAt: new Date().toISOString(),
+  modeId: null,
+  latestStateCheckpointPayload: null,
+  sessionAttributes: {},
+  customStatus: null,
+  ...overrides,
+});
+
+const csatRequested = (): WidgetSystemMessageU => ({
+  id: genUuid(),
+  type: 'SYSTEM',
+  subtype: 'csat_requested',
+  timestamp: new Date(0).toISOString(),
+  data: { payload: undefined },
+});
+
+/**
+ * A widget on a closed session whose survey is live: the request is already
+ * in state, and the poller returns nothing so the only state changes come
+ * from `submitCsat` itself.
+ */
+const widgetWithLiveSurvey = async () => {
+  const session = makeSessionDto();
+  TestUtils.mock.ApiCaller.pollSessionAndHistory(ApiCaller, {
+    data: { session, history: [] },
+  });
+  const widgetCtx = await WidgetCtx.initialize({ config: { token: '' } });
+  widgetCtx.sessionCtx.sessionState.setPartial({ session });
+  widgetCtx.messageCtx.state.setPartial({ messages: [csatRequested()] });
+  await TestUtils.sleep(30);
+  return widgetCtx;
+};
+
+const subtypes = (widgetCtx: WidgetCtx) =>
+  widgetCtx.messageCtx.state
+    .get()
+    .messages.flatMap((m) => (m.type === 'SYSTEM' ? [m.subtype] : []));
+
+suite('CsatCtx.submitCsat', () => {
+  it('accepted → the optimistic submission stays and the survey reads as submitted', async () => {
+    TestUtils.mock.ApiCaller.submitCsat(ApiCaller, { data: { success: true } });
+    const widgetCtx = await widgetWithLiveSurvey();
+
+    const { data } = await widgetCtx.csatCtx.submitCsat({ score: 4, feedback: 'nice' });
+
+    expect(data).toEqual({ success: true });
+    expect(subtypes(widgetCtx)).toEqual(['csat_requested', 'csat_submitted']);
+    expect(deriveCsatState(widgetCtx.messageCtx.state.get().messages)).toMatchObject({
+      isCsatSubmitted: true,
+      submittedScore: 4,
+      submittedFeedback: 'nice',
+    });
+  });
+
+  it('sends the optimistic message id so the poll can dedupe the server copy', async () => {
+    TestUtils.mock.ApiCaller.submitCsat(ApiCaller, { data: { success: true } });
+    const widgetCtx = await widgetWithLiveSurvey();
+
+    await widgetCtx.csatCtx.submitCsat({ score: 4 });
+
+    const submitted = widgetCtx.messageCtx.state
+      .get()
+      .messages.find((m) => m.type === 'SYSTEM' && m.subtype === 'csat_submitted');
+    expect(submitted).toBeDefined();
+    expect(ApiCaller.prototype.submitCsat).toHaveBeenLastCalledWith(
+      expect.objectContaining({ system_message_uuid: submitted?.id, score: 4 }),
+    );
+  });
+
+  it('refused as request_cancelled → rolls the submission back and retires the picker', async () => {
+    TestUtils.mock.ApiCaller.submitCsat(ApiCaller, {
+      data: { success: false, reason: 'request_cancelled' },
+    });
+    const widgetCtx = await widgetWithLiveSurvey();
+
+    const { data } = await widgetCtx.csatCtx.submitCsat({ score: 2 });
+
+    expect(data).toEqual({ success: false, reason: 'request_cancelled' });
+    expect(subtypes(widgetCtx)).toEqual(['csat_requested', 'csat_request_cancelled']);
+    expect(deriveCsatState(widgetCtx.messageCtx.state.get().messages)).toMatchObject({
+      isCsatRequested: false,
+      isCsatSubmitted: false,
+      isCsatCancelled: true,
+    });
+  });
+
+  it('refused as rescore_locked → rolls the submission back, survey stays as it was', async () => {
+    TestUtils.mock.ApiCaller.submitCsat(ApiCaller, {
+      data: { success: false, reason: 'rescore_locked' },
+    });
+    const widgetCtx = await widgetWithLiveSurvey();
+
+    await widgetCtx.csatCtx.submitCsat({ score: 2 });
+
+    expect(subtypes(widgetCtx)).toEqual(['csat_requested']);
+    expect(deriveCsatState(widgetCtx.messageCtx.state.get().messages)).toMatchObject({
+      isCsatRequested: true,
+      isCsatCancelled: false,
+    });
+  });
+
+  it('a plain failure (no reason) → rolls the submission back so the customer can retry', async () => {
+    TestUtils.mock.ApiCaller.submitCsat(ApiCaller, { data: { success: false } });
+    const widgetCtx = await widgetWithLiveSurvey();
+
+    await widgetCtx.csatCtx.submitCsat({ score: 2 });
+
+    expect(subtypes(widgetCtx)).toEqual(['csat_requested']);
+  });
+
+  it('without a session → no call, no state change', async () => {
+    TestUtils.mock.ApiCaller.submitCsat(ApiCaller, { data: { success: true } });
+    const widgetCtx = await WidgetCtx.initialize({ config: { token: '' } });
+    vi.mocked(ApiCaller.prototype.submitCsat).mockClear();
+
+    const result = await widgetCtx.csatCtx.submitCsat({ score: 5 });
+
+    expect(result).toEqual({ data: null, error: 'No session id found' });
+    expect(ApiCaller.prototype.submitCsat).not.toHaveBeenCalled();
+    expect(widgetCtx.messageCtx.state.get().messages).toEqual([]);
+  });
+});

--- a/packages/core/src/__tests__/context/message/on-message-received-hook.spec.ts
+++ b/packages/core/src/__tests__/context/message/on-message-received-hook.spec.ts
@@ -140,6 +140,7 @@ suite('hooks.onMessageReceived', () => {
               value: { content: 'hello from AI', error: false },
               mightSolveUserIssue: false,
               completelyAndFullyCoveredUserIssue: false,
+              assistMode: false,
             },
           },
         });
@@ -185,6 +186,7 @@ suite('hooks.onMessageReceived', () => {
               value: { content: 'reply', error: false },
               mightSolveUserIssue: false,
               completelyAndFullyCoveredUserIssue: false,
+              assistMode: false,
             },
           },
         });
@@ -238,6 +240,7 @@ suite('hooks.onMessageReceived', () => {
               value: { content: 'reply', error: false },
               mightSolveUserIssue: false,
               completelyAndFullyCoveredUserIssue: false,
+              assistMode: false,
             },
           },
         });
@@ -490,6 +493,7 @@ suite('hooks.onMessageReceived', () => {
             value: { content: 'shared reply', error: false },
             mightSolveUserIssue: false,
             completelyAndFullyCoveredUserIssue: false,
+            assistMode: false,
           },
         },
       });

--- a/packages/core/src/__tests__/test-utils.ts
+++ b/packages/core/src/__tests__/test-utils.ts
@@ -76,6 +76,7 @@ export const TestUtils = {
                       id: genUuid(),
                       mightSolveUserIssue: false,
                       completelyAndFullyCoveredUserIssue: false,
+                      assistMode: false,
                     },
                     ...returnValue?.data,
                   },

--- a/packages/core/src/__tests__/utils/derive-csat-state.spec.ts
+++ b/packages/core/src/__tests__/utils/derive-csat-state.spec.ts
@@ -1,0 +1,106 @@
+import type {
+  WidgetMessageU,
+  WidgetSystemMessageU,
+} from '../../types/messages';
+import { deriveCsatState } from '../../utils/derive-csat-state';
+import { genUuid } from '../../utils/uuid';
+
+const requested = (): WidgetSystemMessageU => ({
+  id: genUuid(),
+  type: 'SYSTEM',
+  subtype: 'csat_requested',
+  timestamp: null,
+  data: { payload: undefined },
+});
+const cancelled = (): WidgetSystemMessageU => ({
+  id: genUuid(),
+  type: 'SYSTEM',
+  subtype: 'csat_request_cancelled',
+  timestamp: null,
+  data: { payload: undefined },
+});
+const submitted = (score = 4, feedback = 'ok'): WidgetSystemMessageU => ({
+  id: genUuid(),
+  type: 'SYSTEM',
+  subtype: 'csat_submitted',
+  timestamp: null,
+  data: { payload: { score, feedback } },
+});
+const userMessage = (): WidgetMessageU => ({
+  id: genUuid(),
+  type: 'USER',
+  content: 'hi',
+  deliveredAt: null,
+  timestamp: null,
+});
+
+suite(deriveCsatState.name, () => {
+  it('no CSAT events → nothing is live', () => {
+    const state = deriveCsatState([userMessage()]);
+    expect(state).toMatchObject({
+      isCsatRequested: false,
+      isCsatSubmitted: false,
+      isCsatCancelled: false,
+    });
+  });
+
+  it('requested → the picker is live', () => {
+    const state = deriveCsatState([userMessage(), requested()]);
+    expect(state).toMatchObject({
+      isCsatRequested: true,
+      isCsatSubmitted: false,
+      isCsatCancelled: false,
+    });
+    expect(state.csatRequestedMessage?.subtype).toBe('csat_requested');
+  });
+
+  it('requested then cancelled → voided, picker retired', () => {
+    const state = deriveCsatState([requested(), cancelled()]);
+    expect(state).toMatchObject({
+      isCsatRequested: false,
+      isCsatSubmitted: false,
+      isCsatCancelled: true,
+    });
+  });
+
+  it('cancelled then re-requested → the newer request revives the picker', () => {
+    const state = deriveCsatState([requested(), cancelled(), requested()]);
+    expect(state).toMatchObject({
+      isCsatRequested: true,
+      isCsatCancelled: false,
+    });
+  });
+
+  it('a stray cancel with no request behind it is still not a live picker', () => {
+    const state = deriveCsatState([cancelled()]);
+    expect(state).toMatchObject({
+      isCsatRequested: false,
+      isCsatCancelled: true,
+    });
+  });
+
+  it('submitted wins over a later cancel — an answered survey never un-submits', () => {
+    const state = deriveCsatState([requested(), submitted(5, 'great'), cancelled()]);
+    expect(state).toMatchObject({
+      isCsatRequested: false,
+      isCsatSubmitted: true,
+      isCsatCancelled: false,
+      submittedScore: 5,
+      submittedFeedback: 'great',
+    });
+  });
+
+  it('submitted wins over an earlier cancel too', () => {
+    const state = deriveCsatState([requested(), cancelled(), submitted(2)]);
+    expect(state).toMatchObject({
+      isCsatSubmitted: true,
+      isCsatCancelled: false,
+      submittedScore: 2,
+    });
+  });
+
+  it('the latest submission is the one shown', () => {
+    const state = deriveCsatState([requested(), submitted(1, 'first'), submitted(3, 'second')]);
+    expect(state).toMatchObject({ submittedScore: 3, submittedFeedback: 'second' });
+  });
+});

--- a/packages/core/src/api/schema.ts
+++ b/packages/core/src/api/schema.ts
@@ -739,39 +739,6 @@ export interface components {
       messagePublicId: string | null;
       success: boolean;
     };
-    WidgetConfigDto: {
-      org: {
-        id: string;
-        name: string;
-      };
-      sessionsPollingIntervalSeconds: number;
-      sessionPollingIntervalSeconds: number;
-      modes: {
-        id: string;
-        name: string;
-        slug?: string | null;
-      }[];
-    };
-    WidgetPreludeDto: {
-      org: {
-        id: string;
-        name: string;
-      };
-      sessionsPollingIntervalSeconds: number;
-      sessionPollingIntervalSeconds: number;
-      modes: {
-        id: string;
-        name: string;
-        slug?: string | null;
-      }[];
-    };
-    WidgetContactTokenResponseDto: {
-      /** @description The JWT token to use for further requests */
-      token: string;
-    };
-    WidgetCreateStateCheckpointOutputDto: {
-      success: boolean;
-    };
     /** @enum {string} */
     AssigneeKindEnum: 'human' | 'ai' | 'none';
     /** @enum {string} */
@@ -795,6 +762,7 @@ export interface components {
       | 'ai_reopened_session'
       | 'ai_response_cancelled'
       | 'ai_resumed_by_system'
+      | 'ai_suggestion'
       | 'call_history'
       | 'call_transferred'
       | 'closed_resolved_by_agent'
@@ -806,6 +774,7 @@ export interface components {
       | 'closed_unresolved_by_api'
       | 'closed_unresolved_by_system'
       | 'contact_data_updated'
+      | 'csat_request_cancelled'
       | 'csat_requested'
       | 'csat_submitted'
       | 'email_draft_message'
@@ -814,10 +783,16 @@ export interface components {
       | 'handoff_to_zendesk'
       | 'integration_reopened_session'
       | 'message'
+      | 'pii_attachment_removed'
       | 'prohibited_topic_detected'
+      | 'quoted_content_modified'
       | 'salesforce_fields_updated'
       | 'sequence_message'
       | 'session_forwarded'
+      | 'session_language_changed_by_agent'
+      | 'session_language_changed_by_api'
+      | 'session_language_changed_by_integration'
+      | 'session_language_changed_by_system'
       | 'skills_added_by_system'
       | 'sla_applied_by_agent'
       | 'sla_applied_by_system'
@@ -886,16 +861,23 @@ export interface components {
     SystemMessagePayload:
       | (
           | (
+              | (
+                  | {
+                      /** @constant */
+                      type: 'state_checkpoint';
+                      payload: {
+                        [key: string]: unknown;
+                      } | null;
+                    }
+                  | {
+                      /** @constant */
+                      type: 'csat_requested';
+                      payload?: null;
+                    }
+                )
               | {
                   /** @constant */
-                  type: 'state_checkpoint';
-                  payload: {
-                    [key: string]: unknown;
-                  } | null;
-                }
-              | {
-                  /** @constant */
-                  type: 'csat_requested';
+                  type: 'csat_request_cancelled';
                   payload?: null;
                 }
             )
@@ -913,41 +895,6 @@ export interface components {
           type: 'none';
           payload?: null;
         };
-    WidgetHistoryDto: {
-      publicId: string;
-      type: components['schemas']['MessageTypeEnum'];
-      content: {
-        text?: string | null;
-      };
-      sender: {
-        kind: components['schemas']['SenderTypeEnum'];
-        name?: string | null;
-        avatar?: string | null;
-      };
-      sentAt?: string | null;
-      actionCalls?:
-        | {
-            actionName: string;
-            args: unknown;
-            result: unknown;
-            action: {
-              name: string;
-              id: string;
-              openapi?: {
-                openapi_spec_id?: string;
-                operation_spec: unknown;
-                operation_id?: string;
-                operation_method?: string;
-              };
-              metadata: unknown;
-              required_form_submission?: boolean;
-              is_handoff_like?: boolean;
-            };
-          }[]
-        | null;
-      attachments?: components['schemas']['ChatAttachmentDto'][] | null;
-      systemMessagePayload: components['schemas']['SystemMessagePayload'];
-    };
     WidgetSessionDto: {
       /** Format: uuid */
       id: string;
@@ -987,6 +934,72 @@ export interface components {
       items: components['schemas']['WidgetSessionDto'][];
       next: string | null;
     };
+    WidgetConfigDto: {
+      org: {
+        id: string;
+        name: string;
+      };
+      sessionsPollingIntervalSeconds: number;
+      sessionPollingIntervalSeconds: number;
+      modes: {
+        id: string;
+        name: string;
+        slug?: string | null;
+      }[];
+    };
+    WidgetPreludeDto: {
+      org: {
+        id: string;
+        name: string;
+      };
+      sessionsPollingIntervalSeconds: number;
+      sessionPollingIntervalSeconds: number;
+      modes: {
+        id: string;
+        name: string;
+        slug?: string | null;
+      }[];
+    };
+    WidgetHistoryDto: {
+      publicId: string;
+      type: components['schemas']['MessageTypeEnum'];
+      content: {
+        text?: string | null;
+      };
+      sender: {
+        kind: components['schemas']['SenderTypeEnum'];
+        name?: string | null;
+        avatar?: string | null;
+      };
+      sentAt?: string | null;
+      actionCalls?:
+        | {
+            actionName: string;
+            args: unknown;
+            result: unknown;
+            action: {
+              name: string;
+              id: string;
+              openapi?: {
+                openapi_spec_id?: string;
+                operation_spec: unknown;
+                operation_id?: string;
+                operation_method?: string;
+              };
+              metadata: unknown;
+              required_form_submission?: boolean;
+              is_handoff_like?: boolean;
+            };
+          }[]
+        | null;
+      attachments?: components['schemas']['ChatAttachmentDto'][] | null;
+      systemMessagePayload: components['schemas']['SystemMessagePayload'];
+    };
+    WidgetSessionAndHistoryDto: {
+      /** @description WidgetSession */
+      session: components['schemas']['WidgetSessionDto'];
+      history: components['schemas']['WidgetHistoryDto'][];
+    };
     WidgetSendMessageOutputDto:
       | {
           /** @constant */
@@ -1009,6 +1022,7 @@ export interface components {
             id?: string;
             mightSolveUserIssue: boolean;
             completelyAndFullyCoveredUserIssue: boolean;
+            assistMode: boolean;
             mode?: {
               id: string;
               name: string;
@@ -1053,23 +1067,25 @@ export interface components {
             message?: string;
           };
         };
-    WidgetSubmitCsatOutputDto: {
+    WidgetCreateStateCheckpointOutputDto: {
       success: boolean;
-      /**
-       * @description Why the submit was refused. rescore_locked = the org rescore window has closed, so the recorded score can no longer be changed by the customer
-       * @enum {string}
-       */
-      reason?: 'rescore_locked';
-    };
-    WidgetSessionAndHistoryDto: {
-      /** @description WidgetSession */
-      session: components['schemas']['WidgetSessionDto'];
-      history: components['schemas']['WidgetHistoryDto'][];
     };
     WidgetActionFormSubmissionOutputDto: {
       action: {
         response: unknown;
       };
+    };
+    WidgetSubmitCsatOutputDto: {
+      success: boolean;
+      /**
+       * @description Why the submit was refused. rescore_locked = the org rescore window has closed, so the recorded score can no longer be changed by the customer. request_cancelled = the survey was voided before it was answered, so a rating is no longer accepted at all
+       * @enum {string}
+       */
+      reason?: 'rescore_locked' | 'request_cancelled';
+    };
+    WidgetContactTokenResponseDto: {
+      /** @description The JWT token to use for further requests */
+      token: string;
     };
     UploadWidgetFileResponseDto: {
       fileName: string;

--- a/packages/core/src/context/active-session-polling.ctx.ts
+++ b/packages/core/src/context/active-session-polling.ctx.ts
@@ -238,6 +238,15 @@ export class ActiveSessionPollingCtx {
           timestamp: history.sentAt || '',
           attachments: undefined,
         };
+      case 'csat_request_cancelled':
+        return {
+          id: history.publicId,
+          type: 'SYSTEM',
+          subtype: 'csat_request_cancelled',
+          data: { payload: undefined },
+          timestamp: history.sentAt || '',
+          attachments: undefined,
+        };
       case 'csat_submitted':
         return {
           id: history.publicId,

--- a/packages/core/src/context/csat.ctx.ts
+++ b/packages/core/src/context/csat.ctx.ts
@@ -1,6 +1,9 @@
 import type { ApiCaller } from '../api/api-caller';
 import type { Dto } from '../api/client';
-import type { SafeOmit } from '../types/helpers';
+import type {
+  WidgetSystemMessage__CsatRequestCancelled,
+  WidgetSystemMessage__CsatSubmitted,
+} from '../types/messages';
 import type { WidgetConfig } from '../types/widget-config';
 import { genUuid } from '../utils/uuid';
 import type { MessageCtx } from './message.ctx';
@@ -29,6 +32,12 @@ export class CsatCtx {
     this.messageCtx = messageCtx;
   }
 
+  /**
+   * Optimistic: the `csat_submitted` event is shown before the API answers and
+   * carries the uuid the server will store, so the poll dedupes it. A refusal
+   * (or a failed call) rolls it back — the score was never recorded, so the
+   * picker must not stay locked on it.
+   */
   submitCsat = async (
     body: Pick<Dto['WidgetSubmitCsatInputDto'], 'score' | 'feedback'>,
   ) => {
@@ -37,30 +46,60 @@ export class CsatCtx {
       return { data: null, error: 'No session id found' };
     }
 
-    const uuid = genUuid();
-    this.messageCtx.state.setPartial({
-      messages: [
-        ...this.messageCtx.state.get().messages,
-        {
-          id: uuid,
-          type: 'SYSTEM',
-          subtype: 'csat_submitted',
-          timestamp: new Date().toISOString(),
-          data: {
-            payload: {
-              score: body.score,
-              feedback: body.feedback,
-            },
-          },
+    const optimistic: WidgetSystemMessage__CsatSubmitted = {
+      id: genUuid(),
+      type: 'SYSTEM',
+      subtype: 'csat_submitted',
+      timestamp: new Date().toISOString(),
+      data: {
+        payload: {
+          score: body.score,
+          feedback: body.feedback,
         },
-      ],
-    });
+      },
+    };
+    this.appendMessage(optimistic);
 
     const { data, error } = await this.api.submitCsat({
       ...body,
-      system_message_uuid: uuid,
+      system_message_uuid: optimistic.id,
       session_id: currentSessionId,
     });
+
+    if (!data?.success) {
+      this.removeMessage(optimistic.id);
+      if (data?.reason === 'request_cancelled') {
+        // Retire the picker now rather than on the next poll, which will
+        // deliver the real event (a different id, same meaning).
+        this.appendMessage(this.localCancellation());
+      }
+    }
     return { data, error };
+  };
+
+  private localCancellation = (): WidgetSystemMessage__CsatRequestCancelled => ({
+    id: genUuid(),
+    type: 'SYSTEM',
+    subtype: 'csat_request_cancelled',
+    timestamp: new Date().toISOString(),
+    data: { payload: undefined },
+  });
+
+  private appendMessage = (
+    message:
+      | WidgetSystemMessage__CsatSubmitted
+      | WidgetSystemMessage__CsatRequestCancelled,
+  ) => {
+    this.messageCtx.state.setPartial({
+      messages: [...this.messageCtx.state.get().messages, message],
+    });
+  };
+
+  private removeMessage = (id: string) => {
+    this.messageCtx.state.setPartial({
+      messages: this.messageCtx.state
+        .get()
+        .messages.filter((message) => message.id !== id),
+    });
   };
 }

--- a/packages/core/src/context/csat.ctx.ts
+++ b/packages/core/src/context/csat.ctx.ts
@@ -59,6 +59,7 @@ export class CsatCtx {
       },
     };
     this.appendMessage(optimistic);
+    const answeredRequestId = this.latestRequestId();
 
     const { data, error } = await this.api.submitCsat({
       ...body,
@@ -68,14 +69,24 @@ export class CsatCtx {
 
     if (!data?.success) {
       this.removeMessage(optimistic.id);
-      if (data?.reason === 'request_cancelled') {
-        // Retire the picker now rather than on the next poll, which will
-        // deliver the real event (a different id, same meaning).
+      // Echo the cancel only if no newer request landed while the call was in flight.
+      if (
+        data?.reason === 'request_cancelled' &&
+        this.latestRequestId() === answeredRequestId
+      ) {
         this.appendMessage(this.localCancellation());
       }
     }
     return { data, error };
   };
+
+  private latestRequestId = () =>
+    this.messageCtx.state
+      .get()
+      .messages.findLast(
+        (message) =>
+          message.type === 'SYSTEM' && message.subtype === 'csat_requested',
+      )?.id;
 
   private localCancellation = (): WidgetSystemMessage__CsatRequestCancelled => ({
     id: genUuid(),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,10 +8,13 @@ export type {
   WidgetAiMessage,
   WidgetSystemMessage__StateCheckpoint,
   WidgetSystemMessage__CsatRequested,
+  WidgetSystemMessage__CsatRequestCancelled,
   WidgetSystemMessage__CsatSubmitted,
   WidgetSystemMessageU,
   WidgetMessageU,
 } from './types/messages';
+export { deriveCsatState } from './utils/derive-csat-state';
+export type { CsatState } from './utils/derive-csat-state';
 export type {
   MessageAttachmentType,
   MessageDto,

--- a/packages/core/src/types/messages.ts
+++ b/packages/core/src/types/messages.ts
@@ -85,6 +85,21 @@ export type WidgetSystemMessage__CsatRequested = {
     payload?: undefined;
   };
 };
+/**
+ * The survey was voided before it was answered (a newer session superseded it).
+ * The latest of `csat_requested` / `csat_request_cancelled` decides whether the
+ * picker is live — see `deriveCsatState`.
+ */
+export type WidgetSystemMessage__CsatRequestCancelled = {
+  id: string;
+  type: 'SYSTEM';
+  subtype: 'csat_request_cancelled';
+  timestamp: string | null;
+  attachments?: undefined;
+  data: {
+    payload?: undefined;
+  };
+};
 export type WidgetSystemMessage__CsatSubmitted = {
   id: string;
   type: 'SYSTEM';
@@ -101,6 +116,7 @@ export type WidgetSystemMessage__CsatSubmitted = {
 export type WidgetSystemMessageU =
   | WidgetSystemMessage__StateCheckpoint
   | WidgetSystemMessage__CsatRequested
+  | WidgetSystemMessage__CsatRequestCancelled
   | WidgetSystemMessage__CsatSubmitted;
 
 /* ------------------------------------------------------ */

--- a/packages/core/src/utils/derive-csat-state.ts
+++ b/packages/core/src/utils/derive-csat-state.ts
@@ -1,0 +1,64 @@
+import type {
+  WidgetMessageU,
+  WidgetSystemMessage__CsatRequestCancelled,
+  WidgetSystemMessage__CsatRequested,
+  WidgetSystemMessage__CsatSubmitted,
+} from '../types/messages';
+
+export type CsatState = {
+  csatRequestedMessage: WidgetSystemMessage__CsatRequested | undefined;
+  csatSubmittedMessage: WidgetSystemMessage__CsatSubmitted | undefined;
+  /** The picker is live: requested, not answered, and not voided since. */
+  isCsatRequested: boolean;
+  /** Answered. Wins over everything else regardless of order. */
+  isCsatSubmitted: boolean;
+  /** Voided after the latest request and never answered. */
+  isCsatCancelled: boolean;
+  submittedScore: number | null | undefined;
+  submittedFeedback: string | null | undefined;
+};
+
+/**
+ * CSAT state is a fold over the session's system events, in order:
+ *
+ * - `csat_submitted` anywhere → submitted. A cancellation after an answer is a
+ *   server-side no-op, so it never un-submits.
+ * - otherwise the LATEST of `csat_requested` / `csat_request_cancelled`
+ *   decides: a cancel voids the request before it, a later re-request revives
+ *   the picker.
+ */
+export function deriveCsatState(messages: WidgetMessageU[]): CsatState {
+  const csatRequestedMessage = messages.find(
+    (message): message is WidgetSystemMessage__CsatRequested =>
+      message.type === 'SYSTEM' && message.subtype === 'csat_requested',
+  );
+  const csatSubmittedMessage = messages.findLast(
+    (message): message is WidgetSystemMessage__CsatSubmitted =>
+      message.type === 'SYSTEM' && message.subtype === 'csat_submitted',
+  );
+  const latestRequestOrCancel = messages.findLast(
+    (
+      message,
+    ): message is
+      | WidgetSystemMessage__CsatRequested
+      | WidgetSystemMessage__CsatRequestCancelled =>
+      message.type === 'SYSTEM' &&
+      (message.subtype === 'csat_requested' ||
+        message.subtype === 'csat_request_cancelled'),
+  );
+
+  const isCsatSubmitted = !!csatSubmittedMessage;
+
+  return {
+    csatRequestedMessage,
+    csatSubmittedMessage,
+    isCsatRequested:
+      !isCsatSubmitted && latestRequestOrCancel?.subtype === 'csat_requested',
+    isCsatSubmitted,
+    isCsatCancelled:
+      !isCsatSubmitted &&
+      latestRequestOrCancel?.subtype === 'csat_request_cancelled',
+    submittedScore: csatSubmittedMessage?.data.payload.score,
+    submittedFeedback: csatSubmittedMessage?.data.payload.feedback,
+  };
+}

--- a/packages/embed/CHANGELOG.md
+++ b/packages/embed/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @opencx/widget
 
+## 4.0.63
+
+### Patch Changes
+
+- 2a7e3b3: Retire a rating survey the moment it is withdrawn: the widget now reads the withdrawal event from the session, rolls back a rating the server refused instead of showing it as recorded, and exposes `isCsatCancelled` from `useCsat`.
+
 ## 4.0.62
 
 ### Patch Changes

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencx/widget",
   "private": false,
-  "version": "4.0.62",
+  "version": "4.0.63",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/react-headless/CHANGELOG.md
+++ b/packages/react-headless/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @opencx/widget-react-headless
 
+## 4.0.63
+
+### Patch Changes
+
+- 2a7e3b3: Retire a rating survey the moment it is withdrawn: the widget now reads the withdrawal event from the session, rolls back a rating the server refused instead of showing it as recorded, and exposes `isCsatCancelled` from `useCsat`.
+- Updated dependencies [2a7e3b3]
+  - @opencx/widget-core@4.0.63
+
 ## 4.0.62
 
 ### Patch Changes

--- a/packages/react-headless/package.json
+++ b/packages/react-headless/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencx/widget-react-headless",
   "private": false,
-  "version": "4.0.62",
+  "version": "4.0.63",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/react-headless/src/hooks/useCsat.ts
+++ b/packages/react-headless/src/hooks/useCsat.ts
@@ -1,7 +1,4 @@
-import type {
-  WidgetSystemMessage__CsatRequested,
-  WidgetSystemMessage__CsatSubmitted,
-} from '@opencx/widget-core';
+import { deriveCsatState } from '@opencx/widget-core';
 import { useMemo } from 'react';
 import { useMessages } from './useMessages';
 import { useWidget } from '../WidgetProvider';
@@ -12,40 +9,10 @@ export function useCsat() {
     messagesState: { messages },
   } = useMessages();
 
-  const {
-    csatRequestedMessage,
-    isCsatRequested,
-    csatSubmittedMessage,
-    isCsatSubmitted,
-    submittedScore,
-    submittedFeedback,
-  } = useMemo(() => {
-    const csatRequestedMessage = messages.find(
-      (message): message is WidgetSystemMessage__CsatRequested =>
-        message.type === 'SYSTEM' && message.subtype === 'csat_requested',
-    );
-    const csatSubmittedMessage = messages.findLast(
-      (message): message is WidgetSystemMessage__CsatSubmitted =>
-        message.type === 'SYSTEM' && message.subtype === 'csat_submitted',
-    );
-
-    return {
-      csatRequestedMessage,
-      isCsatRequested: !!csatRequestedMessage && !csatSubmittedMessage,
-      csatSubmittedMessage,
-      isCsatSubmitted: !!csatSubmittedMessage,
-      submittedScore: csatSubmittedMessage?.data.payload.score,
-      submittedFeedback: csatSubmittedMessage?.data.payload.feedback,
-    };
-  }, [messages]);
+  const csatState = useMemo(() => deriveCsatState(messages), [messages]);
 
   return {
     submitCsat: widgetCtx.csatCtx.submitCsat,
-    csatRequestedMessage,
-    isCsatRequested,
-    csatSubmittedMessage,
-    isCsatSubmitted,
-    submittedScore,
-    submittedFeedback,
+    ...csatState,
   };
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @opencx/widget-react
 
+## 4.0.63
+
+### Patch Changes
+
+- 2a7e3b3: Retire a rating survey the moment it is withdrawn: the widget now reads the withdrawal event from the session, rolls back a rating the server refused instead of showing it as recorded, and exposes `isCsatCancelled` from `useCsat`.
+- Updated dependencies [2a7e3b3]
+  - @opencx/widget-core@4.0.63
+  - @opencx/widget-react-headless@4.0.63
+
 ## 4.0.62
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencx/widget-react",
   "private": false,
-  "version": "4.0.62",
+  "version": "4.0.63",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Widget half of OPEN-1090. Depends on opencx-labs/opencx#2701, which puts the `csat_request_cancelled` event on the widget history; ship this after it.

- Regenerate `schema.ts`: `reason` on the submit output and the new system-message subtype. The regen also surfaced `assistMode` becoming required on the AI reply, so the two test fixtures gained it.
- Add `WidgetSystemMessage__CsatRequestCancelled` and its poll-mapper case.
- Move survey-state derivation into `deriveCsatState` in core: a submission wins regardless of order, otherwise the latest of requested / cancelled decides, so a re-request revives the picker. `useCsat` wraps it and exposes `isCsatCancelled`.
- `submitCsat` rolls back the optimistic `csat_submitted` on any non-success and, on `request_cancelled`, echoes a local cancel event so the picker retires before the next poll.

A cancelled survey falls through to the existing "issue resolved" footer; no new copy. Verified end to end in `examples/react-19` against the local backend: cancel via poll, re-request, refused submit rollback, accepted submit.



<!-- greptile_comment -->

🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎
---

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds support for cancelled CSAT requests and safely rolls back optimistic ratings rejected by the server.
- Maps cancellation history events into widget system messages.
- Centralizes CSAT state derivation, including cancellation and re-request behavior.
- Preserves a newer survey request when an older submission is refused.
- Updates generated API types, package versions, changelogs, and tests.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with low risk.

No blocking failure remains; the previous race is addressed by comparing the latest request identity before appending the synthetic cancellation.
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: skip the local cancel echo when a n..."](https://github.com/opencx-labs/widget/commit/5232bf84ca0aeeef2639ddf18dd7ef47fedc70a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60821433)</sub>

<!-- /greptile_comment -->