### PR TITLE
docs: add installable widget integration and migration skills

### DIFF
--- a/docs/widget/agent-skills.mdx
+++ b/docs/widget/agent-skills.mdx
@@ -1,0 +1,95 @@
+---
+title: 'AI coding skills'
+description: 'Give your coding assistant OpenCX widget integration and migration guidance.'
+---
+
+Install an OpenCX skill to help your coding assistant add the widget to your
+website, configure its UI, or migrate an existing integration to v5.
+
+Skills provide instructions to your assistant. Installing a skill does not install
+the widget, change your website, or upgrade your widget version.
+
+## Install a skill
+
+Run this command from your application's directory. You need Node.js and npm,
+including `npx`.
+
+```bash
+npx skills add openchatai/widget --skill opencx-widget-integration
+```
+
+The installer supports assistants including Claude Code, Codex, and Cursor. It can
+detect your assistant or let you choose one. To select explicitly:
+
+```bash
+# Claude Code
+npx skills add openchatai/widget --skill opencx-widget-integration --agent claude-code
+
+# Codex
+npx skills add openchatai/widget --skill opencx-widget-integration --agent codex
+
+# Cursor
+npx skills add openchatai/widget --skill opencx-widget-integration --agent cursor
+```
+
+Installation is scoped to the current project by default. Add `--global` to make
+the skill available across your projects. If the assistant does not discover the
+new skill immediately, start a new session.
+
+## Choose your skill
+
+| Skill                       | Helps with                                                                           |
+| --------------------------- | ------------------------------------------------------------------------------------ |
+| `opencx-widget-integration` | HTML, React, and headless installation; configuration; v5 companion and page context |
+| `opencx-widget-migration`   | Moving an existing v4 integration to v5 and checking custom UI and hosting changes   |
+
+To install the migration skill:
+
+```bash
+npx skills add openchatai/widget --skill opencx-widget-migration
+```
+
+Or install both:
+
+```bash
+npx skills add openchatai/widget --skill opencx-widget-integration opencx-widget-migration
+```
+
+## Ask your assistant
+
+After installing, give your assistant a task and name the skill:
+
+> Use opencx-widget-integration to add the OpenCX widget to this React app using
+> the stable release. Mount it in the app layout.
+
+> Use opencx-widget-integration to configure the v5 beta companion and send the
+> current page context when a visitor asks a question.
+
+> Use opencx-widget-migration to upgrade our v4 widget to v5. Review our custom
+> components and self-hosted script before changing anything.
+
+Your assistant will need your widget token when configuring the integration.
+Get it from your OpenCX dashboard.
+
+## Version awareness
+
+The skills check the installed widget version and available releases before
+recommending changes. v5 features require a v5 package; installing a skill does
+not enable organization features such as streaming or page context.
+
+As of September 6, 2026, v5 is available under the npm `beta` tag and `latest`
+remains v4. Ask explicitly for v5 beta when you want to try it.
+
+## Keep skills current
+
+```bash
+npx skills update opencx-widget-integration opencx-widget-migration
+```
+
+Update the skills you installed. Running `npx skills update` without names updates
+all installed skills. It does not update your npm widget dependency.
+
+See [Install Widget](/widget/install-widget) for manual setup and
+[Configuration](/widget/configuration) for widget options. The
+[skills CLI documentation](https://github.com/vercel-labs/skills) describes
+installation options and supported assistants.

--- a/skills/opencx-widget-integration/SKILL.md
+++ b/skills/opencx-widget-integration/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: opencx-widget-integration
+description: Install and configure the OpenCX chat widget in a customer website using the HTML embed, React components, or headless React hooks. Use for widget integration, branding, page context, and v5 companion setup.
+---
+
+# Integrate the OpenCX widget
+
+Work in the customer's application. Use the published packages and public exports;
+the customer does not need the widget monorepo or a local OpenCX backend.
+
+## Select the version and integration
+
+Inspect the existing dependency, lockfile, or script URL before changing it. Preserve
+the user's version choice. Check registry tags when selecting a new version:
+
+```bash
+npm view @opencx/widget-react dist-tags --json --prefer-online
+```
+
+At verification on 2026-09-06, `latest` is `4.0.62` and `beta` is
+`5.0.0-beta.0` for all four widget packages. Use the stable release for a normal
+installation; use v5 beta when the user requests beta or v5 features. Do not add
+v5-only options to a v4 installation. Re-check tags rather than assuming this
+snapshot is still current. Installing this skill does not install the widget.
+
+| Integration | Package                                                   | Use when                                     |
+| ----------- | --------------------------------------------------------- | -------------------------------------------- |
+| Script      | `@opencx/widget`                                          | Adding the ready-made widget to an HTML site |
+| React       | `@opencx/widget-react`                                    | Using the ready-made UI in a React app       |
+| Headless    | `@opencx/widget-react-headless` and `@opencx/widget-core` | Building a custom UI and persistence flow    |
+
+React packages support React 18 and 19. Use the project's package manager. Install
+core explicitly if the application imports its types; match the widget versions
+when directly depending on multiple OpenCX widget packages.
+
+## HTML installation
+
+Place these tags in the document head. Replace `WIDGET_TOKEN` with the widget token
+from the customer's OpenCX dashboard. Keep script loading and initialization in
+this order; `defer` completes before `DOMContentLoaded`.
+
+```html
+<script
+  defer
+  src="https://unpkg.com/@opencx/widget@latest/dist-embed/script.js"
+></script>
+<script>
+  window.addEventListener('DOMContentLoaded', () => {
+    window.initOpenScript({ token: 'WIDGET_TOKEN' });
+  });
+</script>
+```
+
+For a v5 beta integration, replace `@latest` with the selected exact beta version
+or `@beta`. For inline HTML, provide `<div id="opencx-root"></div>` in the body and
+set `inline: true`. Mount only one integration on a page; do not also mount React
+`Widget` beside the script embed.
+
+In v5, the classic loader installs `initOpenScript` synchronously, then loads
+`widget.js` and a lazy chart chunk. Self-host the entire `dist-embed` directory at
+a versioned URL. Keep old versions available for open tabs that load chunks later.
+Cross-origin module hosting needs CORS. The loader copies its script tag's CSP
+nonce to the injected module; the host's policy must also permit its initialization
+code and any lazy module loads. Copying only `script.js` is insufficient.
+
+## React installation
+
+```bash
+npm install @opencx/widget-react
+```
+
+Use `@opencx/widget-react@beta` instead for an explicitly selected v5 beta.
+Mount the widget once in the app shell:
+
+```tsx
+import { Widget } from '@opencx/widget-react';
+
+export function SupportWidget() {
+  return <Widget options={{ token: 'WIDGET_TOKEN' }} />;
+}
+```
+
+Use the framework's client boundary for browser integration. Read `window`,
+`document`, and browser storage only on the client. The package supplies the styled
+UI; do not invent a CSS package export or import monorepo source paths.
+
+For headless work, consult the [headless guide](https://docs.open.cx/widget/custom-components-headless)
+and the installed declarations. `WidgetProvider` wraps the custom UI; hooks such
+as `useMessages` must run beneath it. The host owns the rendered UI and should
+verify history, loading, errors, and persistence. In v5, a custom streaming UI
+also uses `useAgentChatUi` for live items, stop, queued messages, and clarification.
+`useMessages().messagesState` alone does not describe the whole live turn.
+
+## Configure the public API
+
+Pass configuration under React's `options` prop or directly to `initOpenScript`.
+Use the installed `WidgetConfig` declaration for exact keys and defaults.
+
+- Branding: `theme`, `assets`, `bot`, `humanAgent`, `textContent`, `language`, and
+  `translationOverrides`. Use `cssOverrides` and documented `data-component`
+  selectors for styling within the widget; host-page CSS does not generally cross
+  its iframe boundary.
+- Placement: classic popover by default; `inline: true` for an embedded panel.
+  In v5, `displayMode: 'companion'` selects the companion shell; `companion.layouts`
+  supports `compact`, `sidebar`, and `fullscreen`. Inline rendering takes precedence.
+- Custom UI: `options.customComponents` supplies render slots; React's separate
+  `components` prop replaces named internals. Follow the installed callback types.
+  Slot callbacks receive `react` for rendering with the widget's React instance.
+- Identity: distinguish the organization widget `token` from `user.token` for
+  visitor authentication. Follow the [authentication guide](https://docs.open.cx/widget/authentication)
+  for the selected version; use the application's server for signing credentials.
+  A plain `user.data` object is not a signed identity token.
+
+## v5 context and features
+
+The organization decides whether streaming, dictation, attachments, page context,
+and client tools are enabled. `features.dictation`, `features.pageContext`, and
+`features.clientTools` can disable an enabled feature; `true` does not enable an
+organization-disabled feature. There is no `enablePageMarks` option and no
+`features.attachments` toggle. Companion layout does not itself enable streaming.
+
+Use a context function that reads current application state at send time:
+
+```ts
+const options = {
+  token: 'WIDGET_TOKEN',
+  displayMode: 'companion' as const,
+  context: () => ({
+    page: { url: window.location.href, title: document.title },
+  }),
+};
+```
+
+Host `context` is sent on both engines even if `features.pageContext` is false;
+that flag gates widget-collected page context and related affordances. In v5,
+the entity pill follows URL changes. When context changes without navigation,
+dispatch `window.dispatchEvent(new Event('opencx:context-changed'))` so the pill
+refreshes too. In React, keep changing values behind a ref or store that the
+context function reads: do not assume replacing `options.context` updates every
+initialized core context in beta.0. Do not reinitialize on every route change.
+
+## Verify the integration
+
+Run the host application's build/type checks. In a browser, verify opening,
+sending and receiving a message, history after reload, and the configured layout.
+For v5, exercise streaming/stop if enabled and navigate before sending to confirm
+current context. Check failed script/module requests and `[opencx]` console errors
+when initialization fails. Report which checks required a real widget token and
+which were actually completed.
+
+Use [installation](https://docs.open.cx/widget/install-widget),
+[configuration](https://docs.open.cx/widget/configuration), and the installed
+package declarations for details. Public docs may describe stable v4 while the
+customer runs v5 beta; resolve differences against the selected version.

--- a/skills/opencx-widget-migration/SKILL.md
+++ b/skills/opencx-widget-migration/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: opencx-widget-migration
+description: Migrate a customer's OpenCX widget integration from v4 to v5, checking package versions, self-hosted embed assets, custom rendering, streaming, companion layouts, and page context.
+---
+
+# Migrate OpenCX widget v4 to v5
+
+Work in the customer's application using public packages and declarations. First
+identify its script URL or installed packages, custom slots, CSS overrides,
+authentication, storage, and hosting arrangement. Preserve those choices except
+where the migration requires a change. This skill does not require another skill.
+
+## Choose and install the target version
+
+```bash
+npm view @opencx/widget-react dist-tags --json --prefer-online
+```
+
+Verified on 2026-09-06: v5 is `5.0.0-beta.0` under `beta`; `latest` remains
+`4.0.62`. Re-check before selecting a target. Explain when the selected target is
+a prerelease. For a repeatable beta.0 migration:
+
+```bash
+npm install @opencx/widget-react@5.0.0-beta.0
+```
+
+Use the customer's package manager. For headless integrations, install
+`@opencx/widget-react-headless@5.0.0-beta.0` and
+`@opencx/widget-core@5.0.0-beta.0`. Match any other directly installed OpenCX widget
+packages to that exact version. React 18 and 19 are supported.
+
+For script embeds, use:
+
+```html
+<script
+  defer
+  src="https://unpkg.com/@opencx/widget@5.0.0-beta.0/dist-embed/script.js"
+></script>
+<script>
+  window.addEventListener('DOMContentLoaded', () => {
+    window.initOpenScript({ token: 'WIDGET_TOKEN' });
+  });
+</script>
+```
+
+Keep the default popover unless the customer also requests the companion. The
+companion is selected by `displayMode: 'companion'`; streaming is selected by the
+organization's backend configuration. These are independent choices.
+
+## Review migration-sensitive behavior
+
+- **Self-hosted assets:** v5's `script.js` loads `widget.js`, which can load a lazy
+  chart chunk. Publish the entire `dist-embed` directory at a versioned URL; retain
+  old assets for already-open pages. A short cache lifetime for `widget.js` alone
+  does not protect an open tab whose old module later requests a deleted chunk.
+  Cross-origin module requests need CORS. The loader forwards its nonce; verify
+  the host CSP also allows initialization and lazy imports.
+- **Sanitized HTML:** bot/agent replies and `chatFooterItems` are sanitized. Custom
+  inline styles, scripts, iframes, and other disallowed markup may disappear.
+  Use `cssOverrides` for styling and supported render slots for custom UI.
+  Re-test existing markup rather than promising all v4 customizations are unchanged.
+- **User message shape:** `WidgetUserMessage.deliveredAt` is removed. Read
+  `timestamp` instead. Account for optional `pending`, `markedElements`, and
+  `mentions` when a custom renderer displays user messages. This can affect runtime
+  JavaScript consumers too, not only TypeScript compilation.
+- **Initialization failure:** `Widget` and `WidgetProvider` render nothing by
+  default after a failed initialization and log an error. In React, provide
+  `errorComponent={(error) => ...}` if the host needs a visible failure state.
+- **Styling and branding:** re-check composer CSS, opening motion, and reduced
+  motion. The sessions list can use the organization's agent branding; `bot.name`
+  and `bot.avatarUrl` override it. Header copy uses the organization unless
+  overridden through `textContent.*.headerTitle`.
+- **Backend support:** a backend without an `agent` configuration block selects
+  the classic engine. No frontend `streaming: true` option enables the backend.
+- **Dependency overrides:** React/headless now depend on zod v4. Check overrides
+  that force zod v3 and update the lockfile through the package manager.
+
+## Adopt v5 options when requested
+
+```ts
+import type { WidgetConfig } from '@opencx/widget-core';
+
+const options: WidgetConfig = {
+  token: 'WIDGET_TOKEN',
+  displayMode: 'companion',
+  companion: {
+    layouts: ['compact', 'sidebar', 'fullscreen'],
+    defaultLayout: 'compact',
+    sidebar: { side: 'auto', mode: 'floating', width: 400 },
+  },
+  features: { dictation: false },
+  context: () => ({
+    page: { url: window.location.href, title: document.title },
+  }),
+};
+```
+
+Install matching `@opencx/widget-core` explicitly when importing `WidgetConfig`
+in the host application, and type-check the options against that declaration.
+
+`features.dictation`, `features.pageContext`, and `features.clientTools` narrow the
+organization's enabled features. They cannot turn on disabled organization
+features. Attachments have no per-embed toggle. Page marks use the organization's
+page-context feature; remove any experimental `enablePageMarks` option.
+
+The host's `context` still rides with every send, including when
+`features.pageContext` is false. Use a function reading current state for SPAs.
+For React beta.0, keep changing values in a ref/store read by that function rather
+than assuming a replaced `options.context` updates the classic sending engine.
+URL changes refresh the entity pill; for changes without navigation, dispatch
+`window.dispatchEvent(new Event('opencx:context-changed'))`. A context callback
+must read fresh state, not capture an obsolete route value.
+
+`mentions.items` or `mentions.search` configure the composer's mention picker.
+Mention records use `type`, `id`, and `title`, with optional metadata. Selected
+mentions are sent in `clientContext.mentions` when page context is enabled.
+
+For custom headless streaming UIs, inspect `useAgentChatUi()` for `liveItems`,
+`turnSources`, `isStreaming`, `stop`, `queuedUserMessages`, `removeQueued`,
+`turnFailed`, `retryFailedTurn`, and `pendingClarification`. The stock React widget
+already renders these. A message sent during streaming may steer the live turn;
+other sends queue. Do not promise that every second message becomes a queue pill.
+
+## Verify and report
+
+Build and type-check the customer app. Test the default popover, custom slots and
+CSS, message round trips, attachments, and history after reload. If enabled, test
+streaming, Stop, another send during a reply, and reloaded turn history. For
+companion integrations, test layouts, Escape, mobile sizing, and current context
+after navigation. State which flows were tested against a real backend.
+
+Retain the previous version and configuration in version control for rollback.
+Report the selected version, changed integration files, required hosting changes,
+and outstanding checks. The package migration does not require the customer to
+publish OpenCX packages or modify OpenCX's release tags.


### PR DESCRIPTION
Adds installable OpenCX widget integration and v4-to-v5 migration skills, so coding assistants can guide customers through HTML, React, and headless setup using public packages.

Includes documentation for installing either or both skills with `npx skills add`, selecting an assistant, and updating installed skills. Guidance covers version selection, companion mode, page context, self-hosting, and migration verification.

Validation: Prettier checks passed for all three files; `git diff --cached --check` passed. Documentation-only change; runtime tests were not run.


<!-- greptile_comment -->

🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎
---

<details open><summary><h3>Greptile Summary</h3></summary>

Adds installable coding-assistant skills for integrating the OpenCX widget and migrating customers from v4 to v5.

- Documents skill installation, assistant selection, updates, and version selection.
- Adds HTML, React, headless, self-hosting, page-context, companion-mode, and verification guidance.
- Adds migration guidance covering API changes, custom rendering, streaming, dependencies, and rollback.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Low risk; this documentation-only PR appears safe to merge, with no concrete security, dependency, database, or integration defect identified.

The documented v5 exports, configuration shapes, embed-loading behavior, context handling, migration guidance, and current skills CLI syntax align with the available implementation and contracts.
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add installable widget integration..."](https://github.com/opencx-labs/widget/commit/64ba5dccdf5fe5997634d807248b790c146f3880) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61048397)</sub>

<!-- /greptile_comment -->