### PR TITLE
fix(widget): declare selectable question renderer support

### DIFF
--- a/.changeset/selectable-question-capabilities.md
+++ b/.changeset/selectable-question-capabilities.md
@@ -1,0 +1,8 @@
+---
+'@opencx/widget-core': patch
+'@opencx/widget-react-headless': patch
+'@opencx/widget-react': patch
+'@opencx/widget': patch
+---
+
+Declare support for selectable questions on each request. The built-in widget declares support automatically; headless clients and custom question components declare support with `capabilities.structuredQuestions` after implementing question rendering and answer submission.

--- a/packages/core/src/__tests__/context/message-ctx.send-features.spec.ts
+++ b/packages/core/src/__tests__/context/message-ctx.send-features.spec.ts
@@ -128,6 +128,24 @@ suite('MessageCtx bot-chat send — features on the wire', () => {
     return Object.fromEntries(Object.entries(parsed));
   };
 
+  test('declares renderer support only when the client configured it', async () => {
+    for (const structuredQuestions of [true, false, undefined]) {
+      requests = [];
+      const messageCtx = buildCtx({
+        token: 'tok',
+        capabilities: { structuredQuestions },
+      });
+      await messageCtx.sendMessage({ content: 'hello' });
+      if (structuredQuestions === undefined) {
+        expect(lastSendBody()).not.toHaveProperty('capabilities');
+      } else {
+        expect(lastSendBody().capabilities).toEqual({
+          structured_questions: structuredQuestions,
+        });
+      }
+    }
+  });
+
   test('sends `features` snake_cased when configured', async () => {
     const messageCtx = buildCtx({
       token: 'tok',

--- a/packages/core/src/api/schema.ts
+++ b/packages/core/src/api/schema.ts
@@ -903,7 +903,11 @@ export interface components {
       clientContext?: {
         [key: string]: unknown;
       } | null;
-      /** @description Per-embed feature narrowing: each flag can only switch OFF a feature the organization enabled for its agent (preamble = a heads-up line before tool work; inline_ui = inline rendered components in replies; page_context = the agent sees the page context sent with the message; client_tools = the agent may act on the page). Absent = the organization settings apply. */
+      /** @description What the receiving client can render. Set structured_questions to true only when it renders selectable questions from the streaming response. Missing or false disables the structured question tool; this never enables an organization feature. */
+      capabilities?: {
+        structured_questions?: boolean;
+      } | null;
+      /** @description Per-embed feature narrowing: each flag can only switch OFF a feature the organization enabled for its agent (preamble = progress updates before and during longer tasks; inline_ui = inline rendered components in replies; page_context = the agent sees the page context sent with the message; client_tools = the agent may act on the page). Absent = the organization settings apply. */
       features?: {
         preamble?: boolean;
         inline_ui?: boolean;
@@ -997,6 +1001,9 @@ export interface components {
       | 'ai_assumed_the_session_resolved'
       | 'ai_decided_to_not_reply'
       | 'ai_decided_to_resolve_the_issue'
+      | 'ai_follow_up_cancelled'
+      | 'ai_follow_up_fired'
+      | 'ai_follow_up_scheduled'
       | 'ai_reopened_session'
       | 'ai_response_cancelled'
       | 'ai_resumed_by_system'
@@ -1018,6 +1025,7 @@ export interface components {
       | 'email_draft_message'
       | 'handoff'
       | 'handoff_to_salesforce_miaw'
+      | 'handoff_to_third_party_failed'
       | 'handoff_to_zendesk'
       | 'integration_reopened_session'
       | 'message'
@@ -1263,7 +1271,9 @@ export interface components {
             | 'skipping_unuseful_response'
             | 'duplicate_message_ignored'
             | 'ai_response_skipped_by_workflow'
-            | 'ai_skipped_spam';
+            | 'ai_skipped_spam'
+            | 'steered_into_live_turn'
+            | 'session_busy';
           autopilotResponse?: {
             /** @constant */
             type: 'text';

--- a/packages/core/src/context/message.ctx.ts
+++ b/packages/core/src/context/message.ctx.ts
@@ -198,6 +198,10 @@ export const buildSendMessageBody = ({
   ...mergeSendContext(config, input, { sendsPageContext }),
   language: config.language,
   features: resolveSendFeatures(config),
+  capabilities:
+    config.capabilities?.structuredQuestions === undefined
+      ? undefined
+      : { structured_questions: config.capabilities.structuredQuestions },
   exit_mode_prompt: input.exitModePrompt,
   initial_messages:
     initialMessages.length > 0

--- a/packages/core/src/context/message.ctx.ts
+++ b/packages/core/src/context/message.ctx.ts
@@ -220,6 +220,7 @@ type MessageCtxState = {
 
 export class MessageCtx {
   private config: WidgetConfig;
+  private readonly getClientCapabilities: () => WidgetConfig['capabilities'];
   private api: ApiCaller;
   private contactCtx: ContactCtx;
   private sessionCtx: SessionCtx;
@@ -276,6 +277,7 @@ export class MessageCtx {
     contactCtx,
     streaming,
     sendsPageContext,
+    getClientCapabilities,
   }: {
     config: WidgetConfig;
     api: ApiCaller;
@@ -283,8 +285,12 @@ export class MessageCtx {
     contactCtx: ContactCtx;
     streaming: boolean;
     sendsPageContext: boolean;
+    /** Read renderer support at send time; React options may change after initialization. */
+    getClientCapabilities?: () => WidgetConfig['capabilities'];
   }) {
     this.config = config;
+    this.getClientCapabilities =
+      getClientCapabilities ?? (() => this.config.capabilities);
     this.api = api;
     this.sessionCtx = sessionCtx;
     this.contactCtx = contactCtx;
@@ -661,7 +667,10 @@ export class MessageCtx {
       /* ------------------------------------------------------ */
       const { data } = await this.api.sendMessage(
         buildSendMessageBody({
-          config: this.config,
+          config: {
+            ...this.config,
+            capabilities: this.getClientCapabilities(),
+          },
           input,
           uuid: userMessage.id,
           sessionId,

--- a/packages/core/src/context/widget.ctx.ts
+++ b/packages/core/src/context/widget.ctx.ts
@@ -80,12 +80,14 @@ export class WidgetCtx {
   private constructor({
     config,
     storage,
+    getClientCapabilities,
     modes,
     org,
     agent,
   }: {
     config: WidgetConfig;
     storage?: ExternalStorage;
+    getClientCapabilities?: () => WidgetConfig['capabilities'];
     modes: ModeDto[];
     org: {
       id: string;
@@ -132,6 +134,7 @@ export class WidgetCtx {
       // the blocking bot-chat send.
       streaming: this.streaming,
       sendsPageContext: this.features.pageContext,
+      getClientCapabilities,
     });
 
     this.csatCtx = new CsatCtx({
@@ -164,9 +167,11 @@ export class WidgetCtx {
   static initialize = async ({
     config,
     storage,
+    getClientCapabilities,
   }: {
     config: WidgetConfig;
     storage?: ExternalStorage;
+    getClientCapabilities?: () => WidgetConfig['capabilities'];
   }) => {
     const externalConfig = await new ApiCaller({
       config,
@@ -190,6 +195,7 @@ export class WidgetCtx {
     return new WidgetCtx({
       config,
       storage,
+      getClientCapabilities,
       modes: externalConfig.data.modes || [],
       org: {
         id: externalConfig.data.org.id,

--- a/packages/core/src/types/widget-config.ts
+++ b/packages/core/src/types/widget-config.ts
@@ -374,6 +374,16 @@ export interface WidgetConfig {
    */
   token: string;
 
+  capabilities?: {
+    /**
+     * Whether this client renders selectable question parts and submits answers.
+     * The built-in Widget declares support for its default question renderer.
+     * Headless clients must explicitly declare support after implementing it.
+     * This does not enable the organization's feature. Omitted means unsupported.
+     */
+    structuredQuestions?: boolean;
+  };
+
   /**
    * Per-embed feature toggles. Each one can only NARROW what your
    * organization enabled server-side — `true` (or omitted) leaves the org

--- a/packages/react-headless/README.md
+++ b/packages/react-headless/README.md
@@ -3,3 +3,20 @@
 Headless React helpers and hooks.
 
 For more information, check [the documentation](https://docs.open.cx/widget/getting-started)
+
+## Selectable questions
+
+A custom client must render question choices, collect selections or free text, and submit the answer before declaring support:
+
+```tsx
+<WidgetProvider
+  options={{
+    token: 'YOUR_WIDGET_TOKEN',
+    capabilities: { structuredQuestions: true },
+  }}
+>
+  <YourChat />
+</WidgetProvider>
+```
+
+Omitting this capability leaves the structured question tool unavailable. Ordinary text questions remain available. The organization must also enable **Selectable questions**. The built-in `Widget` declares support automatically for its default question component. If you replace `agent_chat_questions`, explicitly declare support after implementing the replacement.

--- a/packages/react-headless/src/ComponentRegistry.ts
+++ b/packages/react-headless/src/ComponentRegistry.ts
@@ -19,10 +19,11 @@ export class ComponentRegistry {
     }
   }
 
-  // TODO test that this registers or replaces the component
   register(component: WidgetComponentType) {
-    // Replace the key if it already exists
-    const index = this.components.findIndex((c) => c.key === component.key);
+    // Use the same key matching as lookup so the latest renderer is selected.
+    const index = this.components.findIndex(
+      (c) => c.key.toUpperCase() === component.key.toUpperCase(),
+    );
     if (index !== -1) {
       this.components[index] = component;
     } else {

--- a/packages/react-headless/src/WidgetProvider.tsx
+++ b/packages/react-headless/src/WidgetProvider.tsx
@@ -53,6 +53,8 @@ export function WidgetProvider({
    */
   errorComponent?: (error: Error) => React.ReactNode;
 }): React.ReactElement | null {
+  const configRef = useRef(config);
+  configRef.current = config;
   const contentIframeRef = useRef<HTMLIFrameElement | null>(null);
   const initializationRef = useRef<Promise<WidgetCtx> | null>(null);
   const [initialization, setInitialization] = useState<
@@ -72,7 +74,11 @@ export function WidgetProvider({
   useEffect(() => {
     const request =
       initializationRef.current ??
-      (initializationRef.current = WidgetCtx.initialize({ config, storage }));
+      (initializationRef.current = WidgetCtx.initialize({
+        config,
+        storage,
+        getClientCapabilities: () => configRef.current.capabilities,
+      }));
     let active = true;
     void request.then(
       (widgetCtx) => {

--- a/packages/react-headless/src/__tests__/ComponentRegistry.spec.ts
+++ b/packages/react-headless/src/__tests__/ComponentRegistry.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { ComponentRegistry } from '../ComponentRegistry';
+
+const fallback = () => null;
+const builtIn = () => null;
+const replacement = () => null;
+const latest = () => null;
+
+const questionKeys = [
+  'agent_chat_questions',
+  'AGENT_CHAT_QUESTIONS',
+  'Agent_Chat_Questions',
+];
+
+describe('ComponentRegistry renderer replacement', () => {
+  it.each(questionKeys)('replaces the active renderer for %s', (key) => {
+    const registry = new ComponentRegistry({
+      components: [
+        { key: 'fallback', component: fallback },
+        { key: 'agent_chat_questions', component: builtIn },
+      ],
+    });
+    expect(registry.getComponent(key)).toBe(builtIn);
+
+    registry.register({ key, component: replacement });
+    for (const lookupKey of questionKeys) {
+      expect(registry.getComponent(lookupKey)).toBe(replacement);
+    }
+    expect(registry.components).toHaveLength(2);
+    expect(registry.getComponent('fallback')).toBe(fallback);
+
+    registry.register({ key: 'Agent_Chat_Questions', component: latest });
+    expect(registry.getComponent(key)).toBe(latest);
+    expect(registry.components).toHaveLength(2);
+  });
+
+  it('uses the last case-variant registration when constructed with duplicates', () => {
+    const registry = new ComponentRegistry({
+      components: [
+        { key: 'FALLBACK', component: builtIn },
+        { key: 'fallback', component: fallback },
+        { key: 'agent_chat_questions', component: builtIn },
+        { key: 'AGENT_CHAT_QUESTIONS', component: replacement },
+        { key: 'Agent_Chat_Questions', component: latest },
+      ],
+    });
+    expect(registry.getComponent('FALLBACK')).toBe(fallback);
+    expect(registry.getComponent('agent_chat_questions')).toBe(latest);
+    expect(registry.components).toHaveLength(2);
+    expect(registry.getComponent('unknown')).toBeUndefined();
+  });
+});

--- a/packages/react-headless/src/__tests__/WidgetProvider.capabilities.spec.tsx
+++ b/packages/react-headless/src/__tests__/WidgetProvider.capabilities.spec.tsx
@@ -1,0 +1,151 @@
+import { transferableAbortController } from 'node:util';
+import type { SessionDto, WidgetConfig, WidgetCtx } from '@opencx/widget-core';
+import React, { act, useLayoutEffect } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { WidgetProvider, useWidget } from '../WidgetProvider';
+import { useMessages } from '../hooks/useMessages';
+
+const session: SessionDto = {
+  id: 'a3a3a3a3-0000-4000-8000-000000000001',
+  ticketNumber: 1,
+  title: null,
+  createdAt: '2026-09-07T00:00:00.000Z',
+  updatedAt: '2026-09-07T00:00:00.000Z',
+  isHandedOff: false,
+  isOpened: true,
+  assignee: { kind: 'ai', name: null, avatarUrl: null },
+  channel: 'web',
+  isVerified: false,
+  lastMessage: null,
+  modeId: null,
+  latestStateCheckpointPayload: null,
+  sessionAttributes: {},
+  customStatus: null,
+};
+
+function SendProbe({ onContext }: { onContext: (ctx: WidgetCtx) => void }) {
+  const { widgetCtx } = useWidget();
+  const { sendMessage } = useMessages();
+  useLayoutEffect(() => {
+    widgetCtx.sessionCtx.sessionState.setPartial({ session });
+    onContext(widgetCtx);
+  }, [widgetCtx, onContext]);
+  return (
+    <button onClick={() => void sendMessage({ content: 'hello' })}>Send</button>
+  );
+}
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('WidgetProvider blocking capability updates', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('uses the latest declaration on the same initialized client after opt-in, opt-out, and removal', async () => {
+    // Node's Request requires its own AbortSignal, rather than jsdom's version.
+    vi.stubGlobal(
+      'AbortController',
+      class {
+        constructor() {
+          return transferableAbortController();
+        }
+      },
+    );
+    const bodies: unknown[] = [];
+    let configFetches = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request =
+          input instanceof Request ? input : new Request(input, init);
+        if (request.url.endsWith('/config')) {
+          configFetches += 1;
+          return jsonResponse({
+            org: { id: 'org-1', name: 'Org' },
+            sessionPollingIntervalSeconds: 3600,
+            sessionsPollingIntervalSeconds: 3600,
+            modes: [],
+            agent: {
+              name: 'Agent',
+              avatar_url: null,
+              streaming: false,
+              features: {
+                preamble: false,
+                inline_ui: false,
+                dictation: false,
+                attachments: true,
+                page_context: false,
+                client_tools: false,
+              },
+            },
+          });
+        }
+        if (request.url.includes('/poll'))
+          return jsonResponse({ session, history: [] });
+        if (request.url.endsWith('/chat/send')) {
+          const body: unknown = JSON.parse(await request.text());
+          bodies.push(body);
+          return jsonResponse({
+            success: true,
+            autopilotResponse: { value: { content: 'Reply' } },
+          });
+        }
+        throw new Error(`Unexpected request: ${request.method} ${request.url}`);
+      }),
+    );
+    const contexts = new Set<WidgetCtx>();
+    const onContext = (ctx: WidgetCtx) => {
+      contexts.add(ctx);
+    };
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    try {
+      for (const structuredQuestions of [undefined, true, false, undefined]) {
+        const options: WidgetConfig = {
+          token: 'token',
+          collectUserData: true,
+          capabilities:
+            structuredQuestions === undefined
+              ? undefined
+              : { structuredQuestions },
+        };
+        await act(async () =>
+          root.render(
+            <WidgetProvider
+              options={options}
+              components={[{ key: 'fallback', component: () => null }]}
+            >
+              <SendProbe onContext={onContext} />
+            </WidgetProvider>,
+          ),
+        );
+        const button = container.querySelector('button');
+        if (!button) throw new Error('Widget did not initialize');
+        const before = bodies.length;
+        await act(async () => button.click());
+        expect(bodies).toHaveLength(before + 1);
+        if (structuredQuestions === undefined)
+          expect(bodies.at(-1)).not.toHaveProperty('capabilities');
+        else
+          expect(bodies.at(-1)).toMatchObject({
+            capabilities: { structured_questions: structuredQuestions },
+          });
+      }
+      expect(configFetches).toBe(1);
+      expect(contexts.size).toBe(1);
+      expect(
+        Array.from(contexts)[0]?.messageCtx.state.get().messages,
+      ).toHaveLength(8);
+    } finally {
+      act(() => {
+        root.unmount();
+        contexts.forEach((ctx) => ctx.resetChat());
+      });
+    }
+  });
+});

--- a/packages/react-headless/src/agent-chat/__tests__/use-agent-chat.send-features.spec.tsx
+++ b/packages/react-headless/src/agent-chat/__tests__/use-agent-chat.send-features.spec.tsx
@@ -1,3 +1,4 @@
+import type { ChatStatus } from 'ai';
 import type {
   SendMessageInput,
   StagedUserTurn,
@@ -15,10 +16,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
  * the same wire body the blocking engine sends (`buildSendMessageBody`).
  */
 
+const chatState = vi.hoisted((): { status: ChatStatus } => ({
+  status: 'ready',
+}));
 const sendMessageSpy = vi.fn();
 vi.mock('@ai-sdk/react', () => ({
   useChat: () => ({
-    status: 'ready',
+    status: chatState.status,
     messages: [],
     sendMessage: sendMessageSpy,
     stop: vi.fn(),
@@ -93,6 +97,7 @@ describe('useAgentChat stream body — features', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    chatState.status = 'ready';
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
@@ -118,6 +123,25 @@ describe('useAgentChat stream body — features', () => {
     expect(sendMessageSpy).toHaveBeenCalledTimes(1);
     return sendMessageSpy.mock.calls[0]?.[1]?.body;
   }
+
+  it('defaults headless clients to no question renderer and rereads support on every send', async () => {
+    let config: WidgetConfig = { token: 't' };
+    const undeclared = await bodyFor(config);
+    expect(undeclared.capabilities).toBeUndefined();
+    for (const structuredQuestions of [true, false]) {
+      // Complete the preceding stream so the next send starts a new turn.
+      for (const status of ['streaming', 'ready'] as const) {
+        chatState.status = status;
+        await act(async () => root.render(<Probe config={config} />));
+      }
+      sendMessageSpy.mockClear();
+      config = { token: 't', capabilities: { structuredQuestions } };
+      const body = await bodyFor(config);
+      expect(body.capabilities).toEqual({
+        structured_questions: structuredQuestions,
+      });
+    }
+  });
 
   it('sends `features` snake_cased when configured', async () => {
     const body = await bodyFor({

--- a/packages/react/src/__tests__/question-capabilities.spec.tsx
+++ b/packages/react/src/__tests__/question-capabilities.spec.tsx
@@ -1,76 +1,188 @@
+import { transferableAbortController } from 'node:util';
 import type { WidgetConfig } from '@opencx/widget-core';
 import type { WidgetComponentType } from '@opencx/widget-react-headless';
 import React, { act } from 'react';
 import { createRoot } from 'react-dom/client';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
 
-const captured = vi.hoisted((): { options?: WidgetConfig } => ({}));
-vi.mock('@opencx/widget-react-headless', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@opencx/widget-react-headless')>()),
-  WidgetProvider: ({ options }: { options: WidgetConfig }) => {
-    captured.options = options;
+const captured = vi.hoisted(
+  (): {
+    options?: WidgetConfig;
+    renderer?: WidgetComponentType['component'];
+  } => ({}),
+);
+vi.mock('@opencx/widget-react-headless', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@opencx/widget-react-headless')>();
+  function RendererProbe() {
+    const { config, componentStore } = actual.useWidget();
+    captured.options = config;
+    captured.renderer = componentStore.getComponent('agent_chat_questions');
     return null;
-  },
-}));
+  }
+  return {
+    ...actual,
+    // Keep the real provider and registry; replace only the unrelated widget UI.
+    WidgetProvider: (
+      props: React.ComponentProps<typeof actual.WidgetProvider>,
+    ) => (
+      <actual.WidgetProvider {...props}>
+        <RendererProbe />
+      </actual.WidgetProvider>
+    ),
+  };
+});
 
 import { Widget } from '../index';
+import { ClarificationQuestions } from '../components/ClarificationQuestions';
 
 describe('Widget receiving question renderer', () => {
-  it('recognizes custom question keys regardless of casing', () => {
-    const container = document.createElement('div');
-    const root = createRoot(container);
-    try {
-      act(() => root.render(<Widget options={{ token: 't' }} />));
-      expect(captured.options?.capabilities?.structuredQuestions).toBe(true);
-      act(() =>
-        root.render(
-          <Widget
-            options={{ token: 't' }}
-            components={[
-              { key: 'AGENT_CHAT_QUESTIONS', component: () => null },
-            ]}
-          />,
-        ),
-      );
-      expect(captured.options?.capabilities?.structuredQuestions).toBe(false);
-    } finally {
-      act(() => root.unmount());
-    }
+  beforeEach(() => {
+    captured.options = undefined;
+    captured.renderer = undefined;
+    const stored = new Map<string, string>();
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => stored.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        stored.set(key, value);
+      },
+      removeItem: (key: string) => {
+        stored.delete(key);
+      },
+    } satisfies Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>);
+    // Node's Request requires its own AbortSignal, rather than jsdom's version.
+    vi.stubGlobal(
+      'AbortController',
+      class {
+        constructor() {
+          return transferableAbortController();
+        }
+      },
+    );
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request =
+          input instanceof Request ? input : new Request(input, init);
+        if (!request.url.endsWith('/config'))
+          throw new Error(`Unexpected request: ${request.url}`);
+        return new Response(
+          JSON.stringify({
+            org: { id: 'org-1', name: 'Org' },
+            sessionPollingIntervalSeconds: 3600,
+            sessionsPollingIntervalSeconds: 3600,
+            modes: [],
+            agent: {
+              name: 'Agent',
+              avatar_url: null,
+              streaming: false,
+              features: {
+                preamble: false,
+                inline_ui: false,
+                dictation: false,
+                attachments: true,
+                page_context: false,
+                client_tools: false,
+              },
+            },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }),
+    );
   });
+  afterEach(() => vi.unstubAllGlobals());
 
-  it('declares the default renderer, respects opt-outs, and requires custom renderers to opt in', () => {
+  it.each([
+    'agent_chat_questions',
+    'AGENT_CHAT_QUESTIONS',
+    'Agent_Chat_Questions',
+  ])(
+    'keeps declared support aligned with the active %s renderer after rerenders',
+    async (key) => {
+      const container = document.createElement('div');
+      const root = createRoot(container);
+      const CustomQuestions = () => null;
+      try {
+        await act(async () =>
+          root.render(
+            <Widget options={{ token: 't', collectUserData: true }} />,
+          ),
+        );
+        expect(captured.options?.capabilities?.structuredQuestions).toBe(true);
+        expect(captured.renderer).toBe(ClarificationQuestions);
+        for (const structuredQuestions of [undefined, true, false]) {
+          await act(async () =>
+            root.render(
+              <Widget
+                options={{
+                  token: 't',
+                  collectUserData: true,
+                  capabilities: { structuredQuestions },
+                }}
+                components={[{ key, component: CustomQuestions }]}
+              />,
+            ),
+          );
+          expect(captured.options?.capabilities?.structuredQuestions).toBe(
+            structuredQuestions ?? false,
+          );
+          expect(captured.renderer).toBe(CustomQuestions);
+        }
+        await act(async () =>
+          root.render(
+            <Widget options={{ token: 't', collectUserData: true }} />,
+          ),
+        );
+        expect(captured.options?.capabilities?.structuredQuestions).toBe(true);
+        expect(captured.renderer).toBe(ClarificationQuestions);
+        expect(fetch).toHaveBeenCalledTimes(1);
+      } finally {
+        act(() => root.unmount());
+      }
+    },
+  );
+
+  it('declares the default renderer, respects opt-outs, and requires custom renderers to opt in', async () => {
     const container = document.createElement('div');
     const root = createRoot(container);
     const components: WidgetComponentType[] = [
       { key: 'agent_chat_questions', component: () => null },
     ];
     try {
-      act(() => root.render(<Widget options={{ token: 't' }} />));
+      await act(async () =>
+        root.render(<Widget options={{ token: 't', collectUserData: true }} />),
+      );
       expect(captured.options?.capabilities?.structuredQuestions).toBe(true);
-      act(() =>
+      await act(async () =>
         root.render(
           <Widget
             options={{
               token: 't',
+              collectUserData: true,
               capabilities: { structuredQuestions: false },
             }}
           />,
         ),
       );
       expect(captured.options?.capabilities?.structuredQuestions).toBe(false);
-      act(() =>
+      await act(async () =>
         root.render(
-          <Widget options={{ token: 't' }} components={components} />,
+          <Widget
+            options={{ token: 't', collectUserData: true }}
+            components={components}
+          />,
         ),
       );
       expect(captured.options?.capabilities?.structuredQuestions).toBe(false);
-      act(() =>
+      await act(async () =>
         root.render(
           <Widget
             options={{
               token: 't',
+              collectUserData: true,
               capabilities: { structuredQuestions: true },
             }}
             components={components}

--- a/packages/react/src/__tests__/question-capabilities.spec.tsx
+++ b/packages/react/src/__tests__/question-capabilities.spec.tsx
@@ -1,0 +1,63 @@
+import type { WidgetConfig } from '@opencx/widget-core';
+import type { WidgetComponentType } from '@opencx/widget-react-headless';
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { describe, expect, it, vi } from 'vitest';
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+const captured = vi.hoisted((): { options?: WidgetConfig } => ({}));
+vi.mock('@opencx/widget-react-headless', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@opencx/widget-react-headless')>()),
+  WidgetProvider: ({ options }: { options: WidgetConfig }) => {
+    captured.options = options;
+    return null;
+  },
+}));
+
+import { Widget } from '../index';
+
+describe('Widget receiving question renderer', () => {
+  it('declares the default renderer, respects opt-outs, and requires custom renderers to opt in', () => {
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    const components: WidgetComponentType[] = [
+      { key: 'agent_chat_questions', component: () => null },
+    ];
+    try {
+      act(() => root.render(<Widget options={{ token: 't' }} />));
+      expect(captured.options?.capabilities?.structuredQuestions).toBe(true);
+      act(() =>
+        root.render(
+          <Widget
+            options={{
+              token: 't',
+              capabilities: { structuredQuestions: false },
+            }}
+          />,
+        ),
+      );
+      expect(captured.options?.capabilities?.structuredQuestions).toBe(false);
+      act(() =>
+        root.render(
+          <Widget options={{ token: 't' }} components={components} />,
+        ),
+      );
+      expect(captured.options?.capabilities?.structuredQuestions).toBe(false);
+      act(() =>
+        root.render(
+          <Widget
+            options={{
+              token: 't',
+              capabilities: { structuredQuestions: true },
+            }}
+            components={components}
+          />,
+        ),
+      );
+      expect(captured.options?.capabilities?.structuredQuestions).toBe(true);
+    } finally {
+      act(() => root.unmount());
+    }
+  });
+});

--- a/packages/react/src/__tests__/question-capabilities.spec.tsx
+++ b/packages/react/src/__tests__/question-capabilities.spec.tsx
@@ -18,6 +18,28 @@ vi.mock('@opencx/widget-react-headless', async (importOriginal) => ({
 import { Widget } from '../index';
 
 describe('Widget receiving question renderer', () => {
+  it('recognizes custom question keys regardless of casing', () => {
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    try {
+      act(() => root.render(<Widget options={{ token: 't' }} />));
+      expect(captured.options?.capabilities?.structuredQuestions).toBe(true);
+      act(() =>
+        root.render(
+          <Widget
+            options={{ token: 't' }}
+            components={[
+              { key: 'AGENT_CHAT_QUESTIONS', component: () => null },
+            ]}
+          />,
+        ),
+      );
+      expect(captured.options?.capabilities?.structuredQuestions).toBe(false);
+    } finally {
+      act(() => root.unmount());
+    }
+  });
+
   it('declares the default renderer, respects opt-outs, and requires custom renderers to opt in', () => {
     const container = document.createElement('div');
     const root = createRoot(container);

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -142,7 +142,9 @@ const Widget = React.forwardRef<
             ...options.capabilities,
             structuredQuestions:
               options.capabilities?.structuredQuestions ??
-              !components.some(({ key }) => key === 'agent_chat_questions'),
+              !components.some(
+                ({ key }) => key.toUpperCase() === 'AGENT_CHAT_QUESTIONS',
+              ),
           },
         }}
         storage={storage}

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -136,7 +136,15 @@ const Widget = React.forwardRef<
     <MotionConfig reducedMotion="user">
       <WidgetProvider
         components={[...defaultComponents, ...components]}
-        options={options}
+        options={{
+          ...options,
+          capabilities: {
+            ...options.capabilities,
+            structuredQuestions:
+              options.capabilities?.structuredQuestions ??
+              !components.some(({ key }) => key === 'agent_chat_questions'),
+          },
+        }}
         storage={storage}
         loadingComponent={loadingComponent}
         errorComponent={errorComponent}


### PR DESCRIPTION
Declare selectable-question renderer support on every send. Enable the declaration automatically for the built-in question component; require explicit support from headless clients and replacement question components. Preserve explicit opt-outs and reread capabilities on subsequent sends.

Regenerate the widget API contract and include all four packages in the changeset. Release this client update before [backend PR #2766](https://github.com/opencx-labs/opencx/pull/2766) to preserve selectable questions during rollout.








<!-- greptile_comment -->

🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎
---

<details open><summary><h3>Greptile Summary</h3></summary>

The PR declares selectable-question rendering support on each request and keeps that declaration synchronized with current client configuration and the active question renderer.
- Adds the structured-question capability to the generated API contract and widget configuration.
- Rereads capabilities for subsequent blocking and streaming sends.
- Makes component replacement consistent with case-insensitive lookup.
- Adds coverage for rerenders, opt-ins, opt-outs, removals, and case-variant renderer keys.
- Updates headless-client documentation and package changesets.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This PR appears safe to merge, with low risk and no blocking failure remaining.

No blocking failure remains; the previously reported stale-capability and renderer-key mismatches are addressed by send-time configuration reads and consistent case-insensitive matching.
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(widget): match renderer registration..."](https://github.com/opencx-labs/widget/commit/9e24e2a25378e4337a9e5325359ada129d9286c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61252035)</sub>

<!-- /greptile_comment -->