### PR TITLE
fix(widget): apply activity settings consistently

### DIFF
--- a/.changeset/widget-tool-details-setting.md
+++ b/.changeset/widget-tool-details-setting.md
@@ -6,3 +6,5 @@
 ---
 
 Honor dashboard activity settings across tool rows, live replies and saved history, while preserving per-embed opt-outs.
+
+Show progress messages received through polling while the final reply is still being prepared.

--- a/.changeset/widget-tool-details-setting.md
+++ b/.changeset/widget-tool-details-setting.md
@@ -1,0 +1,8 @@
+---
+"@opencx/widget-core": patch
+"@opencx/widget-react-headless": patch
+"@opencx/widget-react": patch
+"@opencx/widget": patch
+---
+
+Honor the dashboard tool-detail setting in the activity display while preserving per-embed opt-outs.

--- a/.changeset/widget-tool-details-setting.md
+++ b/.changeset/widget-tool-details-setting.md
@@ -7,4 +7,4 @@
 
 Honor dashboard activity settings across tool rows, live replies and saved history, while preserving per-embed opt-outs.
 
-Show progress messages received through polling while the final reply is still being prepared.
+Show progress messages received through polling while the final reply is still being prepared. Briefly pause typing as each update arrives, then resume it while waiting for the next reply.

--- a/.changeset/widget-tool-details-setting.md
+++ b/.changeset/widget-tool-details-setting.md
@@ -5,4 +5,4 @@
 "@opencx/widget": patch
 ---
 
-Honor the dashboard tool-detail setting in the activity display while preserving per-embed opt-outs.
+Honor dashboard activity settings across tool rows, live replies and saved history, while preserving per-embed opt-outs.

--- a/.changeset/widget-tool-details-setting.md
+++ b/.changeset/widget-tool-details-setting.md
@@ -8,3 +8,5 @@
 Honor dashboard activity settings across tool rows, live replies and saved history, while preserving per-embed opt-outs.
 
 Show progress messages received through polling while the final reply is still being prepared. Briefly pause typing as each update arrives, then resume it while waiting for the next reply.
+
+Show the copy action only after the reply finishes, leaving no empty action row between progress updates and the typing indicator.

--- a/packages/core/src/__tests__/context/resolve-client-presentation.spec.ts
+++ b/packages/core/src/__tests__/context/resolve-client-presentation.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { resolveClientPresentation } from '../../context/resolve-client-presentation';
+
+describe('client activity limits', () => {
+  it.each([
+    ['hidden', 'hidden', 'hidden'],
+    ['hidden', 'status', 'hidden'],
+    ['hidden', 'details', 'hidden'],
+    ['status', 'hidden', 'hidden'],
+    ['status', 'status', 'status'],
+    ['status', 'details', 'status'],
+    ['details', 'hidden', 'hidden'],
+    ['details', 'status', 'status'],
+    ['details', 'details', 'details'],
+  ] as const)('org %s and embed %s show %s', (org, client, expected) => {
+    expect(
+      resolveClientPresentation(
+        { streaming: true, toolActivity: org, reasoning: true },
+        { toolActivity: client },
+      ),
+    ).toEqual({ toolActivity: expected, reasoning: true });
+  });
+
+  it('inherits the org and allows reasoning to be hidden independently', () => {
+    const org = {
+      streaming: false,
+      toolActivity: 'details',
+      reasoning: true,
+    } as const;
+    expect(resolveClientPresentation(org, undefined)).toEqual({
+      toolActivity: 'details',
+      reasoning: true,
+    });
+    expect(resolveClientPresentation(org, { reasoning: false })).toEqual({
+      toolActivity: 'details',
+      reasoning: false,
+    });
+    expect(
+      resolveClientPresentation(
+        { ...org, reasoning: false },
+        { reasoning: true },
+      ),
+    ).toEqual({
+      toolActivity: 'details',
+      reasoning: false,
+    });
+  });
+
+  it('preserves explicit client limits and omission with older backends', () => {
+    const client = { toolActivity: 'status', reasoning: false } as const;
+    expect(resolveClientPresentation(undefined, client)).toBe(client);
+    expect(resolveClientPresentation(undefined, undefined)).toBeUndefined();
+  });
+});

--- a/packages/core/src/__tests__/context/widget-ctx.features.spec.ts
+++ b/packages/core/src/__tests__/context/widget-ctx.features.spec.ts
@@ -13,7 +13,10 @@ import { TestUtils } from '../test-utils';
  * surface asks it instead of the raw flags.
  */
 suite('WidgetCtx.features (server-enabled, embed-narrowed)', () => {
-  function serverFeatures(overrides: Partial<Dto['WidgetAgentFeaturesDto']>) {
+  function serverFeatures(
+    overrides: Partial<Dto['WidgetAgentFeaturesDto']>,
+    presentation?: Dto['WidgetPresentationDto'],
+  ) {
     TestUtils.mock.ApiCaller.getExternalWidgetConfig(ApiCaller, {
       data: {
         org: { id: 'org-1', name: 'Org One' },
@@ -22,6 +25,7 @@ suite('WidgetCtx.features (server-enabled, embed-narrowed)', () => {
         modes: [],
         agent: {
           name: 'Agent',
+          ...(presentation ? { presentation } : {}),
           avatar_url: null,
           streaming: true,
           features: TestUtils.agentFeatures(overrides),
@@ -51,6 +55,23 @@ suite('WidgetCtx.features (server-enabled, embed-narrowed)', () => {
       pageContext: true,
       clientTools: false,
     });
+  });
+
+  test('preserves organization presentation settings from the config response', async () => {
+    const presentation = {
+      streaming: true,
+      toolActivity: 'details' as const,
+      reasoning: false,
+    };
+    serverFeatures({}, presentation);
+    const ctx = await init();
+    expect(ctx.agent.presentation).toEqual(presentation);
+  });
+
+  test('older backends leave presentation unspecified', async () => {
+    serverFeatures({});
+    const ctx = await init();
+    expect(ctx.agent.presentation).toBeUndefined();
   });
 
   test('org on + embed silent → every feature is on', async () => {

--- a/packages/core/src/context/resolve-client-presentation.ts
+++ b/packages/core/src/context/resolve-client-presentation.ts
@@ -1,0 +1,19 @@
+import type { WidgetAgent } from './widget-agent';
+import type { WidgetConfig } from '../types/widget-config';
+
+/** The embed may hide more activity, but cannot reveal details the org hides. */
+export function resolveClientPresentation(
+  org: WidgetAgent['presentation'],
+  client: WidgetConfig['presentation'],
+): WidgetConfig['presentation'] {
+  if (!org) return client;
+  return {
+    toolActivity:
+      org.toolActivity === 'hidden' || client?.toolActivity === 'hidden'
+        ? 'hidden'
+        : org.toolActivity === 'status' || client?.toolActivity === 'status'
+          ? 'status'
+          : 'details',
+    reasoning: org.reasoning && client?.reasoning !== false,
+  };
+}

--- a/packages/core/src/context/widget-agent.ts
+++ b/packages/core/src/context/widget-agent.ts
@@ -31,10 +31,8 @@ type ServerAgent = Dto['WidgetAgentDto'];
 /**
  * snake_case (backend DTO) → camelCase (widget types) at the boundary.
  *
- * A backend that predates widget v5 — OpenCX main today, until the companion
- * service lands there — returns no `agent` block at all. That is the classic
- * widget: blocking send, attachments on, nothing page-aware — the exact v4
- * behavior, so an embed upgraded ahead of its backend keeps working.
+ * A backend that predates widget v5 returns no `agent` block. Preserve its
+ * blocking send and attachment support when an embed is upgraded first.
  */
 export function resolveWidgetAgent({
   org,

--- a/packages/core/src/context/widget-agent.ts
+++ b/packages/core/src/context/widget-agent.ts
@@ -15,6 +15,8 @@ export type WidgetAgent = {
    * means the classic blocking send.
    */
   streaming: boolean;
+  /** Optional on older backends; controls the maximum visible tool detail. */
+  presentation?: Dto['WidgetPresentationDto'];
   /** The org's EFFECTIVE features (entitlements already applied). */
   features: {
     dictation: boolean;
@@ -58,6 +60,7 @@ export function resolveWidgetAgent({
     name: agent.name,
     avatarUrl: agent.avatar_url,
     streaming: agent.streaming,
+    ...(agent.presentation ? { presentation: agent.presentation } : {}),
     features: {
       dictation: agent.features.dictation,
       attachments: agent.features.attachments,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,6 +54,7 @@ export {
 } from './api/agent-stream-parts';
 
 export { WidgetCtx, WidgetInitializationError } from './context/widget.ctx';
+export { resolveClientPresentation } from './context/resolve-client-presentation';
 export type { WidgetAgent, WidgetClientFeatures } from './context/widget-agent';
 export type { ContactCtx } from './context/contact.ctx';
 export type { SessionCtx } from './context/session.ctx';

--- a/packages/core/src/types/widget-config.ts
+++ b/packages/core/src/types/widget-config.ts
@@ -839,12 +839,10 @@ export interface WidgetConfig {
   onUiAction?: (action: WidgetUiAction) => void;
 
   /**
-   * Makes each step row in an agent turn's trace expandable to show that tool
-   * call's arguments and its result, pretty-printed. For debugging an agent
-   * against a real conversation — the default trace shows only what each step
-   * did, which is what a customer should see.
-   *
-   * @default false
+   * Legacy override for expandable tool arguments and results. When omitted,
+   * follows the dashboard's Tool activity setting. False hides payloads in this
+   * embed; true cannot reveal details prohibited by the dashboard or presentation.
+   * Older backends without presentation settings require an explicit true.
    */
   showStepToolIO?: boolean;
 

--- a/packages/react-headless/src/agent-chat/__tests__/use-agent-chat.client-context.spec.tsx
+++ b/packages/react-headless/src/agent-chat/__tests__/use-agent-chat.client-context.spec.tsx
@@ -76,6 +76,7 @@ function registeredSend(): (input: SendMessageInput) => Promise<void> | void {
 }
 
 const fakeWidgetCtx = {
+  agent: {},
   api: {
     getStreamTransportOptions: () => ({
       api: 'http://test/chat',

--- a/packages/react-headless/src/agent-chat/__tests__/use-agent-chat.drain-order.spec.tsx
+++ b/packages/react-headless/src/agent-chat/__tests__/use-agent-chat.drain-order.spec.tsx
@@ -120,6 +120,7 @@ const fakeApi = {
 };
 
 const fakeWidgetCtx = {
+  agent: {},
   api: fakeApi,
   messageCtx: fakeMessageCtx,
   reconcileAfterStream: fakeReconcileAfterStream,

--- a/packages/react-headless/src/agent-chat/__tests__/use-agent-chat.failed-turn.spec.tsx
+++ b/packages/react-headless/src/agent-chat/__tests__/use-agent-chat.failed-turn.spec.tsx
@@ -88,6 +88,7 @@ function registeredSend(): (input: SendMessageInput) => Promise<void> | void {
 }
 
 const fakeWidgetCtx = {
+  agent: {},
   api: {
     getStreamTransportOptions: () => ({
       api: 'http://test/chat',

--- a/packages/react-headless/src/agent-chat/__tests__/use-agent-chat.feature-narrowing.spec.tsx
+++ b/packages/react-headless/src/agent-chat/__tests__/use-agent-chat.feature-narrowing.spec.tsx
@@ -77,6 +77,7 @@ function registeredSend(): (input: SendMessageInput) => Promise<void> | void {
 const features = { pageContext: true, clientTools: true };
 
 const fakeWidgetCtx = {
+  agent: {},
   api: {
     getStreamTransportOptions: () => ({
       api: 'http://test/chat',

--- a/packages/react-headless/src/agent-chat/__tests__/use-agent-chat.send-features.spec.tsx
+++ b/packages/react-headless/src/agent-chat/__tests__/use-agent-chat.send-features.spec.tsx
@@ -60,6 +60,7 @@ const fakeMessageCtx = {
 };
 
 const fakeWidgetCtx = {
+  agent: {},
   api: {
     getStreamTransportOptions: () => ({
       api: 'http://test/chat',

--- a/packages/react-headless/src/agent-chat/__tests__/use-agent-chat.steer.spec.tsx
+++ b/packages/react-headless/src/agent-chat/__tests__/use-agent-chat.steer.spec.tsx
@@ -157,6 +157,7 @@ function registeredSend(): (input: SendMessageInput) => Promise<void> | void {
 }
 
 const fakeWidgetCtx = {
+  agent: {},
   api: {
     getStreamTransportOptions: () => ({
       api: 'http://test/chat',

--- a/packages/react-headless/src/agent-chat/__tests__/use-agent-chat.stop-partial.spec.tsx
+++ b/packages/react-headless/src/agent-chat/__tests__/use-agent-chat.stop-partial.spec.tsx
@@ -131,6 +131,7 @@ function registeredSend(): (input: SendMessageInput) => Promise<void> | void {
 }
 
 const fakeWidgetCtx = {
+  agent: {},
   api: {
     getStreamTransportOptions: () => ({
       api: 'http://test/chat',

--- a/packages/react-headless/src/agent-chat/__tests__/use-agent-chat.stream-handoff.spec.tsx
+++ b/packages/react-headless/src/agent-chat/__tests__/use-agent-chat.stream-handoff.spec.tsx
@@ -105,6 +105,7 @@ function registeredSend(): (input: SendMessageInput) => Promise<void> | void {
 }
 
 const fakeWidgetCtx = {
+  agent: {},
   api: {
     getStreamTransportOptions: () => ({
       api: 'http://test/chat',

--- a/packages/react-headless/src/agent-chat/__tests__/use-agent-chat.turn-retention.spec.tsx
+++ b/packages/react-headless/src/agent-chat/__tests__/use-agent-chat.turn-retention.spec.tsx
@@ -1,6 +1,7 @@
 import type {
   AgentTurnMessagesDto,
   WidgetConfig,
+  WidgetAgent,
   SendMessageInput,
   StagedUserTurn,
   WidgetCtx,
@@ -122,7 +123,13 @@ function registeredSend(): (input: SendMessageInput) => Promise<void> | void {
 
 // Stable, module-level widgetCtx — the production `WidgetCtx.api` is created
 // once, and the hook's effects rightly assume a stable identity.
+let orgPresentation: WidgetAgent['presentation'];
 const fakeWidgetCtx = {
+  agent: {
+    get presentation() {
+      return orgPresentation;
+    },
+  },
   api: {
     getStreamTransportOptions: () => ({
       api: 'http://test/chat',
@@ -195,6 +202,7 @@ describe('useAgentChat turn retention', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    orgPresentation = undefined;
     getAgentTurnMessages.mockImplementation(async () => null);
     container = document.createElement('div');
     document.body.appendChild(container);
@@ -208,6 +216,67 @@ describe('useAgentChat turn retention', () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
+  });
+
+  it('applies org limits to live and retained activity when the embed requests details', async () => {
+    const presentation = { toolActivity: 'details', reasoning: true } as const;
+    orgPresentation = { streaming: true, ...presentation };
+    await act(async () => root.render(<Probe presentation={presentation} />));
+    await act(async () => {
+      await registeredSend()({ content: 'hey' });
+    });
+    const messages = [
+      {
+        role: 'assistant',
+        parts: [
+          ...ASSISTANT_PARTS,
+          {
+            type: 'data-turn-settled',
+            data: { turn_id: 'T1', message_uuids: ['r-a1'] },
+          },
+          { type: 'reasoning', text: 'reasoning-canary', state: 'done' },
+        ],
+      },
+    ];
+    await act(async () => {
+      setTranscript([{ id: 'u1', type: 'USER' }]);
+      setChatState({ status: 'streaming', messages });
+    });
+    expect(JSON.stringify(hookValue?.liveItems)).toContain('"count":42');
+    expect(JSON.stringify(hookValue?.liveItems)).toContain('reasoning-canary');
+    orgPresentation = {
+      streaming: true,
+      toolActivity: 'status',
+      reasoning: false,
+    };
+    await act(async () => root.render(<Probe presentation={presentation} />));
+    expect(JSON.stringify(hookValue?.liveItems)).toContain('count_sessions');
+    expect(JSON.stringify(hookValue?.liveItems)).not.toContain('"count":42');
+    expect(JSON.stringify(hookValue?.liveItems)).not.toContain(
+      'reasoning-canary',
+    );
+    await act(async () => setChatState({ status: 'ready', messages }));
+    await act(async () =>
+      setTranscript([
+        { id: 'u1', type: 'USER' },
+        { id: 'r-a1', type: 'AI' },
+      ]),
+    );
+    expect(hookValue?.turnSources).toHaveLength(1);
+    expect(JSON.stringify(hookValue?.turnSources)).toContain('count_sessions');
+    expect(JSON.stringify(hookValue?.turnSources)).not.toContain('"count":42');
+    expect(JSON.stringify(hookValue?.turnSources)).not.toContain(
+      'reasoning-canary',
+    );
+    // Local narrowing preserves the source. History requests carry only embed
+    // limits so the backend can apply the org's current settings.
+    orgPresentation = { streaming: true, ...presentation };
+    await act(async () => root.render(<Probe presentation={presentation} />));
+    expect(JSON.stringify(hookValue?.turnSources)).toContain('"count":42');
+    expect(getAgentTurnMessages).toHaveBeenLastCalledWith(
+      'sess-1',
+      presentation,
+    );
   });
 
   it('retains the streamed message synchronously from the terminal turn-identity part', async () => {

--- a/packages/react-headless/src/agent-chat/useAgentChat.ts
+++ b/packages/react-headless/src/agent-chat/useAgentChat.ts
@@ -1,6 +1,7 @@
 import { useChat } from '@ai-sdk/react';
 import {
   buildSendMessageBody,
+  resolveClientPresentation,
   genUuid,
   log,
   type SendMessageInput,
@@ -903,6 +904,13 @@ export function useAgentChat({
     queueVersion,
   ]);
 
+  const visiblePresentation = resolveClientPresentation(
+    widgetCtx.agent.presentation,
+    config.presentation,
+  );
+  const visibleToolActivity = visiblePresentation?.toolActivity;
+  const visibleReasoning = visiblePresentation?.reasoning;
+
   // The live overlay: the in-flight assistant message's ordered items. Held
   // through `settling` as well as the stream itself — see above.
   const liveItems: StreamingTurnItem[] = useMemo(() => {
@@ -910,22 +918,22 @@ export function useAgentChat({
     const last = messages.at(-1);
     if (!last || last.role !== 'assistant') return [];
     return applyPresentation(mapUiPartsToItems(last.parts), {
-      toolActivity,
-      reasoning,
+      toolActivity: visibleToolActivity,
+      reasoning: visibleReasoning,
     });
-  }, [messages, isStreaming, settling, toolActivity, reasoning]);
+  }, [messages, isStreaming, settling, visibleToolActivity, visibleReasoning]);
 
   const visibleTurnSources = useMemo(
     () =>
       turnSources.flatMap((source) => {
         const items = applyPresentation(source.items, {
-          toolActivity,
-          reasoning,
+          toolActivity: visibleToolActivity,
+          reasoning: visibleReasoning,
         });
         if (items.length === 0) return [];
         return [items === source.items ? source : { ...source, items }];
       }),
-    [turnSources, toolActivity, reasoning],
+    [turnSources, visibleToolActivity, visibleReasoning],
   );
 
   // Messages the user queued mid-turn — surfaced so the composer can render

--- a/packages/react/src/components/AgentMessageGroup.tsx
+++ b/packages/react/src/components/AgentMessageGroup.tsx
@@ -30,8 +30,7 @@ export function AgentMessageGroup({
   agent: Agent | undefined;
   suggestedReplies?: string[];
   /**
-   * Offer the reply actions (copy). Off for a reply that is still streaming:
-   * its text is not final yet.
+   * Offer the reply actions (copy) only when its text is final.
    */
   actions?: boolean;
 }) {

--- a/packages/react/src/components/StepsGroup.tsx
+++ b/packages/react/src/components/StepsGroup.tsx
@@ -1,3 +1,4 @@
+import { resolveClientPresentation } from '@opencx/widget-core';
 import {
   useConfig,
   useWidget,
@@ -348,14 +349,14 @@ export function StepsGroup({
   const { t } = useTranslation();
   const { showStepToolIO, presentation } = useConfig();
   const { widgetCtx } = useWidget();
-  const orgActivity = widgetCtx.agent.presentation?.toolActivity;
-  const clientActivity = presentation?.toolActivity;
+  const activity = resolveClientPresentation(
+    widgetCtx.agent.presentation,
+    presentation,
+  )?.toolActivity;
   const showToolDetails =
     showStepToolIO !== false &&
-    (orgActivity === undefined || orgActivity === 'details') &&
-    (clientActivity === undefined
-      ? showStepToolIO === true || orgActivity === 'details'
-      : clientActivity === 'details');
+    (activity === 'details' ||
+      (activity === undefined && showStepToolIO === true));
   const thinkingLabel = t('thinking');
   // Once the turn is over nothing is running: a turn that ended with a step
   // unfinished — a stopped turn leaves its last tool call at

--- a/packages/react/src/components/StepsGroup.tsx
+++ b/packages/react/src/components/StepsGroup.tsx
@@ -1,4 +1,8 @@
-import { useConfig, type StreamingStep } from '@opencx/widget-react-headless';
+import {
+  useConfig,
+  useWidget,
+  type StreamingStep,
+} from '@opencx/widget-react-headless';
 import { ChevronDownIcon, ChevronRightIcon } from 'lucide-react';
 import React, { useEffect, useRef, useState } from 'react';
 import { dc } from '../utils/data-component';
@@ -271,7 +275,7 @@ function ToolPayload({ label, value }: { label: string; value: unknown }) {
 }
 
 /**
- * One tool call in the trace. With `showStepToolIO` on, the row is a
+ * One tool call in the trace. When full details are allowed, the row is a
  * disclosure: it opens onto the call's arguments and its result, which is what
  * you actually need when an agent's answer is wrong and the label ("Search
  * knowledge base") tells you nothing about what it searched for. Off — the
@@ -342,7 +346,16 @@ export function StepsGroup({
   active,
 }: StreamingStepsComponentProps) {
   const { t } = useTranslation();
-  const { showStepToolIO } = useConfig();
+  const { showStepToolIO, presentation } = useConfig();
+  const { widgetCtx } = useWidget();
+  const orgActivity = widgetCtx.agent.presentation?.toolActivity;
+  const clientActivity = presentation?.toolActivity;
+  const showToolDetails =
+    showStepToolIO !== false &&
+    (orgActivity === undefined || orgActivity === 'details') &&
+    (clientActivity === undefined
+      ? showStepToolIO === true || orgActivity === 'details'
+      : clientActivity === 'details');
   const thinkingLabel = t('thinking');
   // Once the turn is over nothing is running: a turn that ended with a step
   // unfinished — a stopped turn leaves its last tool call at
@@ -430,7 +443,7 @@ export function StepsGroup({
                   thinkingLabel={thinkingLabel}
                 />
               ) : (
-                <ToolRow step={step} showIO={showStepToolIO === true} />
+                <ToolRow step={step} showIO={showToolDetails} />
               )}
             </div>
           ))}

--- a/packages/react/src/components/StreamingTurn.tsx
+++ b/packages/react/src/components/StreamingTurn.tsx
@@ -1,4 +1,7 @@
-import type { WidgetAiMessage } from '@opencx/widget-core';
+import {
+  resolveClientPresentation,
+  type WidgetAiMessage,
+} from '@opencx/widget-core';
 import type {
   SpecDataPart,
   StreamingTurnItem,
@@ -37,7 +40,7 @@ export function StreamingTurn({
 }) {
   // Registered by `Widget` (`agent_chat_steps` / `agent_chat_spec`) and
   // replaceable through the `components` prop.
-  const { componentStore, config } = useWidget();
+  const { componentStore, config, widgetCtx } = useWidget();
   const StepsComponent = componentStore.getComponent('agent_chat_steps');
   const SpecComponent = componentStore.getComponent('agent_chat_spec');
   // Fixed for the life of the turn. A fresh `new Date()` per render would make
@@ -45,7 +48,13 @@ export function StreamingTurn({
   // persisted row (stamped once, server-side) takes over at the handoff.
   const [startedAt] = useState(() => new Date().toISOString());
   const groupTimestamp = timestamp ?? startedAt;
-  const items = applyPresentation(turn.items, config.presentation);
+  const items = applyPresentation(
+    turn.items,
+    resolveClientPresentation(
+      widgetCtx.agent.presentation,
+      config.presentation,
+    ),
+  );
 
   // `questions` renders NOTHING in the transcript. A pending clarification
   // takes the composer's place instead (`ChatInput`), so the customer answers

--- a/packages/react/src/components/__tests__/steps-group-collapse.spec.tsx
+++ b/packages/react/src/components/__tests__/steps-group-collapse.spec.tsx
@@ -7,6 +7,7 @@ Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
 
 vi.mock('@opencx/widget-react-headless', () => ({
   useConfig: () => ({}),
+  useWidget: () => ({ widgetCtx: { agent: {} } }),
 }));
 vi.mock('../../hooks/useTranslation', () => ({
   useTranslation: () => ({ t: (key: string) => key, dir: 'ltr' }),

--- a/packages/react/src/components/__tests__/steps-reasoning-markdown.spec.tsx
+++ b/packages/react/src/components/__tests__/steps-reasoning-markdown.spec.tsx
@@ -14,6 +14,7 @@ Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
 
 vi.mock('@opencx/widget-react-headless', () => ({
   useConfig: () => ({ showStepToolIO: false }),
+  useWidget: () => ({ widgetCtx: { agent: {} } }),
 }));
 
 vi.mock('../../hooks/useTranslation', () => ({

--- a/packages/react/src/components/__tests__/steps-tool-io.spec.tsx
+++ b/packages/react/src/components/__tests__/steps-tool-io.spec.tsx
@@ -12,9 +12,21 @@ Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
  */
 
 let showStepToolIO: boolean | undefined;
+let orgActivity: 'hidden' | 'status' | 'details' | undefined;
+let clientActivity: 'hidden' | 'status' | 'details' | undefined;
 
 vi.mock('@opencx/widget-react-headless', () => ({
-  useConfig: () => ({ showStepToolIO }),
+  useConfig: () => ({
+    showStepToolIO,
+    presentation: { toolActivity: clientActivity },
+  }),
+  useWidget: () => ({
+    widgetCtx: {
+      agent: {
+        presentation: orgActivity ? { toolActivity: orgActivity } : undefined,
+      },
+    },
+  }),
 }));
 
 vi.mock('../../hooks/useTranslation', () => ({
@@ -37,6 +49,8 @@ describe('StepsGroup tool IO', () => {
 
   beforeEach(() => {
     showStepToolIO = true;
+    orgActivity = undefined;
+    clientActivity = undefined;
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
@@ -72,6 +86,43 @@ describe('StepsGroup tool IO', () => {
     expect(container.textContent).toContain('refund policy');
     expect(container.textContent).toContain('step_result');
     expect(container.textContent).toContain('"hits": 3');
+  });
+
+  it('uses the dashboard full-details setting without a legacy embed option', () => {
+    showStepToolIO = undefined;
+    orgActivity = 'details';
+    render([toolStep]);
+    expect(container.querySelector('.cursor-pointer')).not.toBeNull();
+    act(() => container.querySelector<HTMLElement>('.cursor-pointer')?.click());
+    expect(container.textContent).toContain('refund policy');
+    expect(container.textContent).toContain('"hits": 3');
+  });
+
+  it.each(['hidden', 'status'] as const)(
+    'does not override the org %s setting with a legacy opt-in',
+    (activity) => {
+      orgActivity = activity;
+      clientActivity = 'details';
+      render([toolStep]);
+      expect(container.querySelector('.cursor-pointer')).toBeNull();
+    },
+  );
+
+  it.each(['hidden', 'status'] as const)(
+    'honors the client %s opt-out with org full details',
+    (activity) => {
+      orgActivity = 'details';
+      clientActivity = activity;
+      render([toolStep]);
+      expect(container.querySelector('.cursor-pointer')).toBeNull();
+    },
+  );
+
+  it('keeps an explicit legacy opt-out', () => {
+    orgActivity = 'details';
+    showStepToolIO = false;
+    render([toolStep]);
+    expect(container.querySelector('.cursor-pointer')).toBeNull();
   });
 
   it('leaves the row alone when the option is off', () => {

--- a/packages/react/src/components/__tests__/streaming-turn-customization.spec.tsx
+++ b/packages/react/src/components/__tests__/streaming-turn-customization.spec.tsx
@@ -12,6 +12,7 @@ const config = vi.hoisted((): WidgetConfig => ({ token: 'test' }));
 vi.mock('@opencx/widget-react-headless', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@opencx/widget-react-headless')>()),
   useWidget: () => ({
+    widgetCtx: { agent: {} },
     config,
     componentStore: {
       getComponent: (key: string) => components.get(key) ?? null,

--- a/packages/react/src/components/__tests__/streaming-turn-working.spec.tsx
+++ b/packages/react/src/components/__tests__/streaming-turn-working.spec.tsx
@@ -11,6 +11,7 @@ const config = vi.hoisted((): WidgetConfig => ({ token: 'test' }));
 vi.mock('@opencx/widget-react-headless', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@opencx/widget-react-headless')>()),
   useWidget: () => ({
+    widgetCtx: { agent: {} },
     config,
     componentStore: {
       getComponent: () => () => <div data-steps />,

--- a/packages/react/src/screens/chat/ChatMain.tsx
+++ b/packages/react/src/screens/chat/ChatMain.tsx
@@ -84,7 +84,10 @@ export function ChatMain() {
       <ChatBannerItems />
       <InitialMessages />
 
-      <MessageGroups groups={groupedMessages} />
+      <MessageGroups
+        groups={groupedMessages}
+        pendingReply={isAwaitingBotReply}
+      />
 
       {/* Typing indicator while awaiting the (blocking) bot reply. */}
       {showTypingIndicator && LoadingComponent && (

--- a/packages/react/src/screens/chat/ChatMain.tsx
+++ b/packages/react/src/screens/chat/ChatMain.tsx
@@ -11,10 +11,7 @@ import {
 import React, { useEffect, useMemo, useRef } from 'react';
 import { SessionResolvedComponent } from '../../components/custom-components/SessionResolvedComponent';
 import { dc } from '../../utils/data-component';
-import {
-  groupMessagesByType,
-  isBotMessageGroup,
-} from '../../utils/group-messages-by-type';
+import { groupMessagesByType } from '../../utils/group-messages-by-type';
 import { ChatBannerItems } from './ChatBannerItems';
 import { ChatCustomStatus } from './ChatCustomStatus';
 import { InitialMessages } from './InitialMessages';
@@ -33,17 +30,6 @@ export function ChatMain() {
     () => groupMessagesByType(messages),
     [messages],
   );
-
-  // While the blocking send awaits its reply, an AI group polled in early
-  // must not render above the typing indicator — it would double-render the
-  // reply when the send resolves.
-  const visibleGroups = useMemo(() => {
-    const last = groupedMessages.at(-1);
-    if (isAwaitingBotReply && last && isBotMessageGroup(last)) {
-      return groupedMessages.slice(0, -1);
-    }
-    return groupedMessages;
-  }, [groupedMessages, isAwaitingBotReply]);
 
   const LoadingComponent = componentStore.getComponent(
     'loading' satisfies SafeExtract<LiteralWidgetComponentKey, 'loading'>,
@@ -76,7 +62,7 @@ export function ChatMain() {
       <ChatBannerItems />
       <InitialMessages />
 
-      <MessageGroups groups={visibleGroups} />
+      <MessageGroups groups={groupedMessages} />
 
       {/* Typing indicator while awaiting the (blocking) bot reply. */}
       {isAwaitingBotReply && LoadingComponent && (

--- a/packages/react/src/screens/chat/ChatMain.tsx
+++ b/packages/react/src/screens/chat/ChatMain.tsx
@@ -8,7 +8,7 @@ import {
   useMessages,
   useWidget,
 } from '@opencx/widget-react-headless';
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { SessionResolvedComponent } from '../../components/custom-components/SessionResolvedComponent';
 import { dc } from '../../utils/data-component';
 import { groupMessagesByType } from '../../utils/group-messages-by-type';
@@ -31,6 +31,28 @@ export function ChatMain() {
     [messages],
   );
 
+  const lastMessage = messages.at(-1);
+  const lastMessageId = lastMessage?.id;
+  const lastMessageType = lastMessage?.type;
+  const previousMessageId = useRef(lastMessageId);
+  const [typingPaused, setTypingPaused] = useState(false);
+  const showTypingIndicator = isAwaitingBotReply && !typingPaused;
+
+  useEffect(() => {
+    const receivedMessage = previousMessageId.current !== lastMessageId;
+    previousMessageId.current = lastMessageId;
+    if (!isAwaitingBotReply || lastMessageType !== 'AI') {
+      setTypingPaused(false);
+      return;
+    }
+    if (!receivedMessage) return;
+
+    // Let each completed update land before showing that more is coming.
+    setTypingPaused(true);
+    const resumeTyping = setTimeout(() => setTypingPaused(false), 600);
+    return () => clearTimeout(resumeTyping);
+  }, [isAwaitingBotReply, lastMessageId, lastMessageType]);
+
   const LoadingComponent = componentStore.getComponent(
     'loading' satisfies SafeExtract<LiteralWidgetComponentKey, 'loading'>,
   );
@@ -50,7 +72,7 @@ export function ChatMain() {
 
   useEffect(() => {
     handleNewMessage();
-  }, [messages]);
+  }, [messages, showTypingIndicator]);
 
   return (
     <div
@@ -65,7 +87,7 @@ export function ChatMain() {
       <MessageGroups groups={groupedMessages} />
 
       {/* Typing indicator while awaiting the (blocking) bot reply. */}
-      {isAwaitingBotReply && LoadingComponent && (
+      {showTypingIndicator && LoadingComponent && (
         <LoadingComponent agent={bot} />
       )}
 

--- a/packages/react/src/screens/chat/MessageGroups.tsx
+++ b/packages/react/src/screens/chat/MessageGroups.tsx
@@ -15,13 +15,20 @@ import {
  * (server-resolved agent branding wins); human-agent groups prefer the
  * server-provided sender, patched by the `humanAgent` config override.
  */
-export function MessageGroups({ groups }: { groups: WidgetMessageU[][] }) {
+export function MessageGroups({
+  groups,
+  pendingReply = false,
+}: {
+  groups: WidgetMessageU[][];
+  /** The latest reply is still being prepared, including between polled updates. */
+  pendingReply?: boolean;
+}) {
   const { humanAgent } = useConfig();
   const bot = useBot();
 
   return (
     <>
-      {groups.map((group) => {
+      {groups.map((group, index) => {
         const firstIdInGroup = group[0]?.id;
         if (!firstIdInGroup) return null;
 
@@ -35,6 +42,7 @@ export function MessageGroups({ groups }: { groups: WidgetMessageU[][] }) {
               key={firstIdInGroup}
               messages={group}
               agent={bot}
+              actions={!pendingReply || index !== groups.length - 1}
             />
           );
         }

--- a/packages/react/src/screens/chat/__tests__/chat-main.polling-progress.spec.tsx
+++ b/packages/react/src/screens/chat/__tests__/chat-main.polling-progress.spec.tsx
@@ -46,6 +46,7 @@ import { ChatMain } from '../ChatMain';
 let root: Root;
 let container: HTMLDivElement;
 beforeEach(() => {
+  vi.useFakeTimers();
   container = document.createElement('div');
   document.body.appendChild(container);
   root = createRoot(container);
@@ -57,6 +58,7 @@ beforeEach(() => {
 afterEach(() => {
   act(() => root.unmount());
   container.remove();
+  vi.useRealTimers();
 });
 
 it('shows polled progress while the blocking send is pending and keeps it after completion', () => {
@@ -75,6 +77,8 @@ it('shows polled progress while the blocking send is pending and keeps it after 
   ];
   act(() => root.render(<ChatMain />));
   expect(container.textContent).toContain('I am checking your balance.');
+  expect(container.textContent).not.toContain('Still working');
+  act(() => vi.advanceTimersByTime(600));
   expect(container.textContent).toContain('Still working');
   messages = [
     ...messages,
@@ -97,4 +101,66 @@ it('shows polled progress while the blocking send is pending and keeps it after 
     1,
   );
   expect(container.textContent).not.toContain('Still working');
+});
+
+it('pauses for each new update without restarting the pause for repeated polls', () => {
+  act(() => root.render(<ChatMain />));
+  for (const id of ['balance-progress', 'revenue-progress']) {
+    messages = [
+      ...messages,
+      {
+        id,
+        type: 'AI',
+        component: 'bot_message',
+        data: { message: `Checking ${id}.` },
+        timestamp: null,
+      },
+    ];
+    act(() => root.render(<ChatMain />));
+    expect(container.textContent).toContain(`Checking ${id}.`);
+    expect(container.textContent).not.toContain('Still working');
+    act(() => vi.advanceTimersByTime(300));
+    messages = [...messages];
+    act(() => root.render(<ChatMain />));
+    expect(container.textContent).not.toContain('Still working');
+    act(() => vi.advanceTimersByTime(300));
+    expect(container.textContent).toContain('Still working');
+  }
+});
+
+it('does not resume typing when the reply finishes during the pause', () => {
+  act(() => root.render(<ChatMain />));
+  messages = [
+    ...messages,
+    {
+      id: 'final',
+      type: 'AI',
+      component: 'bot_message',
+      data: { message: 'Your balance is 468 dollars.' },
+      timestamp: null,
+    },
+  ];
+  act(() => root.render(<ChatMain />));
+  expect(container.textContent).not.toContain('Still working');
+  awaitingReply = false;
+  act(() => root.render(<ChatMain />));
+  act(() => vi.advanceTimersByTime(1_000));
+  expect(container.textContent).toContain('Your balance is 468 dollars.');
+  expect(container.textContent).not.toContain('Still working');
+});
+
+it('keeps typing visible when mounting with an existing progress message', () => {
+  messages = [
+    ...messages,
+    {
+      id: 'existing-progress',
+      type: 'AI',
+      component: 'bot_message',
+      data: { message: 'I am checking your balance.' },
+      timestamp: null,
+    },
+  ];
+  act(() => root.render(<ChatMain />));
+  expect(container.textContent).toContain('I am checking your balance.');
+  expect(container.textContent).toContain('Still working');
 });

--- a/packages/react/src/screens/chat/__tests__/chat-main.polling-progress.spec.tsx
+++ b/packages/react/src/screens/chat/__tests__/chat-main.polling-progress.spec.tsx
@@ -1,0 +1,100 @@
+import type { WidgetMessageU } from '@opencx/widget-core';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+let messages: WidgetMessageU[] = [];
+let awaitingReply = true;
+vi.mock('@opencx/widget-react-headless', () => ({
+  useMessages: () => ({ messagesState: { messages } }),
+  useIsAwaitingBotReply: () => ({ isAwaitingBotReply: awaitingReply }),
+  useBot: () => undefined,
+  useWidget: () => ({
+    componentStore: { getComponent: () => () => <span>Still working</span> },
+  }),
+}));
+vi.mock('../MessageGroups', () => ({
+  MessageGroups: ({ groups }: { groups: WidgetMessageU[][] }) => (
+    <div>
+      {groups.flat().map((message) => (
+        <p key={message.id} data-message-id={message.id}>
+          {message.type === 'USER'
+            ? message.content
+            : message.type === 'AI'
+              ? message.data.message
+              : null}
+        </p>
+      ))}
+    </div>
+  ),
+}));
+vi.mock('../ChatCustomStatus', () => ({ ChatCustomStatus: () => null }));
+vi.mock('../ChatBannerItems', () => ({ ChatBannerItems: () => null }));
+vi.mock('../InitialMessages', () => ({ InitialMessages: () => null }));
+vi.mock('../../../components/custom-components/ChatBottomComponents', () => ({
+  ChatBottomComponents: () => null,
+}));
+vi.mock(
+  '../../../components/custom-components/SessionResolvedComponent',
+  () => ({ SessionResolvedComponent: () => null }),
+);
+
+import { ChatMain } from '../ChatMain';
+
+let root: Root;
+let container: HTMLDivElement;
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  awaitingReply = true;
+  messages = [
+    { id: 'user', type: 'USER', content: 'Check my balance.', timestamp: null },
+  ];
+});
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+it('shows polled progress while the blocking send is pending and keeps it after completion', () => {
+  act(() => root.render(<ChatMain />));
+  expect(container.textContent).toContain('Check my balance.');
+  expect(container.textContent).toContain('Still working');
+  messages = [
+    ...messages,
+    {
+      id: 'progress',
+      type: 'AI',
+      component: 'bot_message',
+      data: { message: 'I am checking your balance.' },
+      timestamp: null,
+    },
+  ];
+  act(() => root.render(<ChatMain />));
+  expect(container.textContent).toContain('I am checking your balance.');
+  expect(container.textContent).toContain('Still working');
+  messages = [
+    ...messages,
+    {
+      id: 'final',
+      type: 'AI',
+      component: 'bot_message',
+      data: { message: 'Your balance is 468 dollars.' },
+      timestamp: null,
+    },
+  ];
+  act(() => root.render(<ChatMain />));
+  expect(container.textContent).toContain('Your balance is 468 dollars.');
+  awaitingReply = false;
+  act(() => root.render(<ChatMain />));
+  expect(
+    container.querySelectorAll('[data-message-id="progress"]'),
+  ).toHaveLength(1);
+  expect(container.querySelectorAll('[data-message-id="final"]')).toHaveLength(
+    1,
+  );
+  expect(container.textContent).not.toContain('Still working');
+});

--- a/packages/react/src/screens/chat/__tests__/chat-main.polling-progress.spec.tsx
+++ b/packages/react/src/screens/chat/__tests__/chat-main.polling-progress.spec.tsx
@@ -7,28 +7,45 @@ Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
 
 let messages: WidgetMessageU[] = [];
 let awaitingReply = true;
+const writeText = vi.fn(async () => {});
+const originalClipboard = Object.getOwnPropertyDescriptor(
+  navigator,
+  'clipboard',
+);
 vi.mock('@opencx/widget-react-headless', () => ({
   useMessages: () => ({ messagesState: { messages } }),
   useIsAwaitingBotReply: () => ({ isAwaitingBotReply: awaitingReply }),
   useBot: () => undefined,
+  useConfig: () => ({}),
+  useDisplayMode: () => 'companion',
   useWidget: () => ({
     componentStore: { getComponent: () => () => <span>Still working</span> },
   }),
 }));
-vi.mock('../MessageGroups', () => ({
-  MessageGroups: ({ groups }: { groups: WidgetMessageU[][] }) => (
+vi.mock('../../../components/AgentMessage', () => ({
+  AgentMessage: (message: WidgetMessageU) => (
+    <p data-message-id={message.id}>
+      {message.type === 'AI' ? message.data.message : null}
+    </p>
+  ),
+}));
+vi.mock('../../../components/UserMessageGroup', () => ({
+  UserMessageGroup: ({ messages }: { messages: WidgetMessageU[] }) => (
     <div>
-      {groups.flat().map((message) => (
+      {messages.map((message) => (
         <p key={message.id} data-message-id={message.id}>
-          {message.type === 'USER'
-            ? message.content
-            : message.type === 'AI'
-              ? message.data.message
-              : null}
+          {message.type === 'USER' ? message.content : null}
         </p>
       ))}
     </div>
   ),
+}));
+vi.mock('../../../components/AgentAvatar', () => ({ AgentAvatar: () => null }));
+vi.mock('../../../components/lib/tooltip', () => ({
+  Tooltippy: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('../../../hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (key: string) => key, dir: 'ltr' }),
 }));
 vi.mock('../ChatCustomStatus', () => ({ ChatCustomStatus: () => null }));
 vi.mock('../ChatBannerItems', () => ({ ChatBannerItems: () => null }));
@@ -47,6 +64,10 @@ let root: Root;
 let container: HTMLDivElement;
 beforeEach(() => {
   vi.useFakeTimers();
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: { writeText },
+  });
   container = document.createElement('div');
   document.body.appendChild(container);
   root = createRoot(container);
@@ -58,6 +79,12 @@ beforeEach(() => {
 afterEach(() => {
   act(() => root.unmount());
   container.remove();
+  if (originalClipboard) {
+    Object.defineProperty(navigator, 'clipboard', originalClipboard);
+  } else {
+    Reflect.deleteProperty(navigator, 'clipboard');
+  }
+  writeText.mockClear();
   vi.useRealTimers();
 });
 
@@ -163,4 +190,67 @@ it('keeps typing visible when mounting with an existing progress message', () =>
   act(() => root.render(<ChatMain />));
   expect(container.textContent).toContain('I am checking your balance.');
   expect(container.textContent).toContain('Still working');
+});
+
+it('omits the pending reply action row until completion, including during the typing pause', async () => {
+  messages = [
+    {
+      id: 'earlier-reply',
+      type: 'AI',
+      component: 'bot_message',
+      data: { message: 'An earlier completed reply.' },
+      timestamp: null,
+    },
+    ...messages,
+  ];
+  const actionRows = () =>
+    container.querySelectorAll(
+      '[data-component="chat/agent_msg_group/actions"]',
+    );
+  act(() => root.render(<ChatMain />));
+  expect(actionRows()).toHaveLength(1);
+
+  messages = [
+    ...messages,
+    {
+      id: 'progress',
+      type: 'AI',
+      component: 'bot_message',
+      data: { message: 'Checking your balance.' },
+      timestamp: null,
+    },
+  ];
+  act(() => root.render(<ChatMain />));
+  expect(container.textContent).toContain('Checking your balance.');
+  expect(container.textContent).not.toContain('Still working');
+  expect(actionRows()).toHaveLength(1);
+  act(() => vi.advanceTimersByTime(600));
+  expect(container.textContent).toContain('Still working');
+  expect(actionRows()).toHaveLength(1);
+
+  messages = [
+    ...messages,
+    {
+      id: 'final',
+      type: 'AI',
+      component: 'bot_message',
+      data: { message: 'Your balance is 468 dollars.' },
+      timestamp: null,
+    },
+  ];
+  act(() => root.render(<ChatMain />));
+  expect(container.textContent).toContain('Your balance is 468 dollars.');
+  expect(actionRows()).toHaveLength(1);
+
+  awaitingReply = false;
+  act(() => root.render(<ChatMain />));
+  expect(container.textContent).not.toContain('Still working');
+  expect(actionRows()).toHaveLength(2);
+  const copyButtons = container.querySelectorAll<HTMLButtonElement>(
+    '[data-component="chat/agent_msg_group/actions/copy"]',
+  );
+  await act(async () => copyButtons.item(1).click());
+  expect(writeText).toHaveBeenCalledWith(
+    'Checking your balance.\n\nYour balance is 468 dollars.',
+  );
 });


### PR DESCRIPTION
Selecting **Full details** in the dashboard previously still showed only tool names unless the embed also set `showStepToolIO`. Preserve the org presentation settings and apply one shared visibility policy to tool rows, live replies and saved history.

Let embeds reduce tool activity and reasoning independently while retaining the org limits. Keep the legacy false opt-out and older-backend behavior. Cover setting changes during a turn and after history loads, and include a changeset for all four packages.

Show polled progress messages immediately while the final reply is pending; core already reconciles duplicate message IDs. Briefly pause typing when each new message arrives, resume it while waiting, and stop it when the reply finishes. Verify repeated polls do not restart the pause and completion cannot revive typing.

Render copy actions only after the current reply finishes. Omit the action row entirely while polling progress is pending, including pauses in the typing indicator, so no invisible row adds space below progress messages. Keep completed reply actions available.

Companion backend PR: https://github.com/opencx-labs/opencx/pull/2789. Merge this before publishing the next widget beta; publish all four packages together, then update the backend PR's dashboard dependency before deployment.









<!-- greptile_comment -->

🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎
---

<details open><summary><h3>Greptile Summary</h3></summary>

The PR consistently applies organization and embed presentation limits across live activity, retained turns, and tool details, while improving the display of polled progress messages.
- Preserves organization presentation settings and resolves them against embed-level restrictions.
- Applies the resolved visibility policy to live, retained, and rendered activity.
- Displays pending progress messages and coordinates reply actions with the typing indicator.
- Updates the previously broken `StepsGroup` test mock.
- Risk level: Low; no database migrations or dependency additions are included.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with low risk.

No blocking failure remains.
</details>

<sub>Reviews (5): Last reviewed commit: ["fix(widget): show copy only after the re..."](https://github.com/opencx-labs/widget/commit/ed02c646233ff775ed124152c48be550650d5026) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61617164)</sub>

<!-- /greptile_comment -->