### PR TITLE
fix(widget): restore production startup in beta.5

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -14,6 +14,7 @@
     "selectable-question-capabilities",
     "widget-delivery-controls",
     "widget-follow-up-order",
+    "widget-production-build",
     "widget-tool-details-setting",
     "widget-v5-beta"
   ]

--- a/.changeset/widget-production-build.md
+++ b/.changeset/widget-production-build.md
@@ -1,0 +1,8 @@
+---
+'@opencx/widget-core': patch
+'@opencx/widget-react-headless': patch
+'@opencx/widget-react': patch
+'@opencx/widget': patch
+---
+
+Fix widget startup in production applications.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,14 @@ Always commit the version bump (package.json + CHANGELOG.md changes) after publi
 - `pnpm cs` — create a changeset
 - `pnpm csv` — apply changesets (bumps versions)
 - `pnpm csp` — full check (clean, build, type-check, test) then publish
+- `pnpm release:beta` — full clean/build/lint/type-check/test gate, then publish all four packages sequentially with the `beta` tag. Use this for beta releases after `pnpm csv`.
+
+Every package build explicitly sets `NODE_ENV=production`, regardless of the
+calling shell. Both the build and `prepack` run
+`scripts/check-production-build.mjs`, which rejects development JSX in the
+compiled JavaScript. Do not skip lifecycle scripts when publishing. A green
+development preview does not verify a production bundle; check the packed
+release in a production consumer too.
 
 ### When the npm account has 2FA on writes
 
@@ -29,11 +37,10 @@ writes", each of those four authenticates separately and npm rate-limits the
 one-time-password endpoint: `E429 ... rate limited otp`, nothing published.
 That is what happened cutting `5.0.0-beta.0`.
 
-Run the gate and the publish as two steps instead:
+Use the sequential beta release command instead:
 
 ```bash
-pnpm x                                              # the same gate csp runs
-pnpm publish -r --tag beta --no-git-checks          # sequential, one package at a time
+pnpm release:beta
 ```
 
 `pnpm publish -r` covers exactly the four publishable packages (the tooling

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "turbo build",
     "lint": "turbo lint",
     "type-check": "turbo type-check",
-    "test": "turbo test",
+    "test": "pnpm test:build && turbo test",
     "/* --------------------- DEVELOPMENT -------------------- */": "",
     "dev:prepare": "dotenv -- turbo dev:prepare --env-mode",
     "dev": "dotenv -- turbo dev --env-mode",
@@ -22,7 +22,8 @@
     "cs:pre:exit": "changeset pre exit",
     "cs": "changeset",
     "csv": "changeset version",
-    "csp": "pnpm x && changeset publish"
+    "csp": "pnpm x && changeset publish",
+    "test:build": "node --test scripts/check-production-build.test.mjs"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.9",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "cs": "changeset",
     "csv": "changeset version",
     "csp": "pnpm x && changeset publish",
+    "release:beta": "pnpm x && pnpm publish -r --tag beta --no-git-checks",
     "test:build": "node --test scripts/check-production-build.test.mjs"
   },
   "devDependencies": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @opencx/widget-core
 
+## 5.0.0-beta.5
+
+### Patch Changes
+
+- Fix widget startup in production applications.
+
 ## 5.0.0-beta.4
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,12 +10,13 @@
   "scripts": {
     "clean": "rm -rf node_modules dist .turbo",
     "clean:dist": "rm -rf dist .turbo",
-    "build": "vite build",
+    "build": "NODE_ENV=production vite build && node ../../scripts/check-production-build.mjs dist",
     "gen:sdk": "pnpm dlx openapi-typescript http://localhost:8080/backend/widget-api-json -o ./src/api/schema.ts && prettier --write ./src/api/schema.ts",
     "test": "vitest run",
     "type-check": "tsc --noEmit",
     "lint": "eslint .",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "prepack": "node ../../scripts/check-production-build.mjs dist"
   },
   "files": [
     "dist"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencx/widget-core",
   "private": false,
-  "version": "5.0.0-beta.4",
+  "version": "5.0.0-beta.5",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/embed/CHANGELOG.md
+++ b/packages/embed/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @opencx/widget
 
+## 5.0.0-beta.5
+
+### Patch Changes
+
+- Fix widget startup in production applications.
+
 ## 5.0.0-beta.4
 
 ### Patch Changes

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencx/widget",
   "private": false,
-  "version": "5.0.0-beta.4",
+  "version": "5.0.0-beta.5",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -10,11 +10,12 @@
   "scripts": {
     "clean": "rm -rf node_modules dist-embed .turbo",
     "clean:dist": "rm -rf dist-embed .turbo",
-    "build": "vite build -c vite.config.ts && vite build -c vite.loader.config.ts",
+    "build": "NODE_ENV=production vite build -c vite.config.ts && NODE_ENV=production vite build -c vite.loader.config.ts && node ../../scripts/check-production-build.mjs dist-embed",
     "test": "vitest run",
     "type-check": "tsc --noEmit",
     "lint": "eslint .",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "prepack": "node ../../scripts/check-production-build.mjs dist-embed"
   },
   "files": [
     "dist-embed",

--- a/packages/react-headless/CHANGELOG.md
+++ b/packages/react-headless/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @opencx/widget-react-headless
 
+## 5.0.0-beta.5
+
+### Patch Changes
+
+- Fix widget startup in production applications.
+- Updated dependencies
+  - @opencx/widget-core@5.0.0-beta.5
+
 ## 5.0.0-beta.4
 
 ### Patch Changes

--- a/packages/react-headless/package.json
+++ b/packages/react-headless/package.json
@@ -10,11 +10,12 @@
   "scripts": {
     "clean": "rm -rf node_modules dist .turbo",
     "clean:dist": "rm -rf dist .turbo",
-    "build": "vite build",
+    "build": "NODE_ENV=production vite build && node ../../scripts/check-production-build.mjs dist",
     "test": "vitest run",
     "type-check": "tsc --noEmit",
     "lint": "eslint .",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "prepack": "node ../../scripts/check-production-build.mjs dist"
   },
   "files": [
     "dist"

--- a/packages/react-headless/package.json
+++ b/packages/react-headless/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencx/widget-react-headless",
   "private": false,
-  "version": "5.0.0-beta.4",
+  "version": "5.0.0-beta.5",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @opencx/widget-react
 
+## 5.0.0-beta.5
+
+### Patch Changes
+
+- Fix widget startup in production applications.
+- Updated dependencies
+  - @opencx/widget-core@5.0.0-beta.5
+  - @opencx/widget-react-headless@5.0.0-beta.5
+
 ## 5.0.0-beta.4
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencx/widget-react",
   "private": false,
-  "version": "5.0.0-beta.4",
+  "version": "5.0.0-beta.5",
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,12 +11,13 @@
     "clean": "rm -rf node_modules dist .turbo",
     "clean:dist": "rm -rf dist .turbo",
     "dev": "vite --host",
-    "build": "vite build -c vite.config.ts",
+    "build": "NODE_ENV=production vite build -c vite.config.ts && node ../../scripts/check-production-build.mjs dist",
     "gen:ui-prompt": "tsx scripts/generate-ui-prompt.ts",
     "test": "vitest run",
     "type-check": "tsc --noEmit",
     "lint": "eslint .",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "prepack": "node ../../scripts/check-production-build.mjs dist"
   },
   "files": [
     "dist"

--- a/scripts/check-production-build.mjs
+++ b/scripts/check-production-build.mjs
@@ -1,0 +1,32 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+const directory = process.argv[2];
+if (!directory)
+  throw new Error('Usage: node check-production-build.mjs <output-directory>');
+
+const root = resolve(directory);
+const files = (await readdir(root, { recursive: true })).filter((file) =>
+  /\.[cm]?js$/.test(file),
+);
+if (files.length === 0)
+  throw new Error(`No compiled JavaScript found in ${root}. Build first.`);
+
+for (const file of files) {
+  const source = await readFile(resolve(root, file), 'utf8');
+  // Some production dependencies expose a dormant `jsxDEV` option. Reject
+  // development-runtime imports, bundled development runtimes, and calls.
+  if (
+    /react\/jsx-dev-runtime|react-jsx(?:-dev)?-runtime\.development|\bjsxDEV\s*\(/.test(
+      source,
+    )
+  ) {
+    throw new Error(
+      `Development JSX found in ${resolve(root, file)}. Rebuild with NODE_ENV=production before publishing.`,
+    );
+  }
+}
+
+console.log(
+  `Production JSX check passed: ${files.length} JavaScript files in ${directory}.`,
+);

--- a/scripts/check-production-build.test.mjs
+++ b/scripts/check-production-build.test.mjs
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const checker = fileURLToPath(
+  new URL('./check-production-build.mjs', import.meta.url),
+);
+
+test('accepts production JSX and ignores source maps', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'widget-production-jsx-'));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  await writeFile(
+    join(directory, 'index.js'),
+    'import { jsx } from "react/jsx-runtime"; jsx("div", {});',
+  );
+  await writeFile(
+    join(directory, 'index.js.map'),
+    JSON.stringify({ sourcesContent: ['jsxDEV'] }),
+  );
+  await writeFile(
+    join(directory, 'markdown.cjs'),
+    'exports.check = options => typeof options.jsxDEV === "function";',
+  );
+  const result = spawnSync(process.execPath, [checker, directory], {
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /2 JavaScript files/);
+});
+
+for (const { filename, source } of [
+  {
+    filename: 'chunk.mjs',
+    source:
+      'import { jsxDEV as n } from "react/jsx-dev-runtime"; n("div", {});',
+  },
+  {
+    filename: 'chunk.cjs',
+    source: 'const r = require("react/jsx-dev-runtime"); r.jsxDEV("div", {});',
+  },
+  {
+    filename: 'chunk.js',
+    source: 'const element = runtime.jsxDEV("div", {});',
+  },
+  {
+    filename: 'runtime.js',
+    source:
+      '/*! react-jsx-dev-runtime.development.js */ function createElement() {}',
+  },
+]) {
+  test(`rejects development JSX in a nested ${filename}`, async (t) => {
+    const directory = await mkdtemp(join(tmpdir(), 'widget-development-jsx-'));
+    t.after(() => rm(directory, { recursive: true, force: true }));
+    await writeFile(
+      join(directory, 'index.js'),
+      'export const version = "test";',
+    );
+    const clean = spawnSync(process.execPath, [checker, directory], {
+      encoding: 'utf8',
+    });
+    assert.equal(clean.status, 0, clean.stderr);
+    await mkdir(join(directory, 'chunks'));
+    await writeFile(join(directory, 'chunks', filename), source);
+    const result = spawnSync(process.execPath, [checker, directory], {
+      encoding: 'utf8',
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /Development JSX found/);
+    assert.ok(result.stderr.includes(filename));
+  });
+}
+
+test('rejects an output directory without compiled JavaScript', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'widget-empty-build-'));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  const result = spawnSync(process.execPath, [checker, directory], {
+    encoding: 'utf8',
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /No compiled JavaScript/);
+});

--- a/turbo.json
+++ b/turbo.json
@@ -2,7 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "globalEnv": ["*"],
   "ui": "stream",
-  "globalDependencies": [".env"],
+  "globalDependencies": [".env", "scripts/check-production-build.mjs"],
   "tasks": {
     "clean": {},
     "clean:dist": {},


### PR DESCRIPTION
Fix the production startup crash caused by beta.4 containing development-only JSX calls. Development React masked the failure.

Force production mode for all four package builds and reject development JSX during build and packing. Add `pnpm release:beta` to run the clean build, lint, type checks, and tests before sequential publishing with the beta tag. Release all four packages as `5.0.0-beta.5`.

Validate 973 package tests and 6 build-guard tests, reject the actual published beta.4 artifact, and render the packed beta.5 widget in an isolated production browser build with local test configuration.


<!-- greptile_comment -->

🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎
---

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restores production-safe widget package builds for the beta.5 release.
- Forces production mode across all four package builds.
- Adds build and prepack checks that reject development JSX artifacts.
- Adds regression tests and updates release scripts, package versions, changesets, and changelogs.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with low risk; no concrete functional or security defects were identified, and it contains no database migrations or new dependencies.

The changed build and packing paths consistently force production mode and validate emitted JavaScript, with focused regression coverage for the production-startup failure.
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(widget): release 5.0.0-beta.5"](https://github.com/opencx-labs/widget/commit/fb6d8a9bbad94f71f272a88fc9c105d368317736) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62189770)</sub>

<!-- /greptile_comment -->