### PR TITLE
translate the close, zoom, and panel labels that stayed English

### DIFF
--- a/.changeset/translate-remaining-hardcoded-labels.md
+++ b/.changeset/translate-remaining-hardcoded-labels.md
@@ -1,0 +1,10 @@
+---
+'@opencx/widget-core': patch
+'@opencx/widget-react-headless': patch
+'@opencx/widget-react': patch
+'@opencx/widget': patch
+---
+
+Translate the last labels that still rendered in English regardless of the
+configured language: the close-conversation confirmation, the dialog's dismiss
+label, the image zoom controls, and the chat panel's accessibility label.

--- a/packages/core/src/__tests__/translation.spec.ts
+++ b/packages/core/src/__tests__/translation.spec.ts
@@ -33,6 +33,40 @@ describe('translations', () => {
     );
   });
 
+  // These keys replaced literals that sat in the components, so every locale
+  // had been rendering English. `getTranslation` falls back to English, which
+  // means "not empty" would still pass for a locale that was skipped — assert
+  // the copy actually moved.
+  const previouslyHardcoded = [
+    'close_conversation_title',
+    'close_conversation_description',
+    'close_conversation_cancel',
+    'close_conversation_confirm',
+    'dialog_close',
+    'zoom_in',
+    'zoom_out',
+    'reset_zoom',
+    'support_chat_aria_label',
+  ] satisfies TranslationKeyU[];
+
+  it.each(['ar', 'ja', 'ru'] as const)(
+    '%s localizes the labels that used to be hardcoded',
+    (language) => {
+      // Positive control: this locale really is being read, so a failure below
+      // means untranslated copy rather than a broken lookup.
+      expect(getTranslation('close_conversation_cancel', 'ar', undefined)).toBe(
+        'لا',
+      );
+
+      const stillEnglish = previouslyHardcoded.filter(
+        (key) =>
+          getTranslation(key, language, undefined) === EnglishLanguage[key],
+      );
+
+      expect(stillEnglish).toEqual([]);
+    },
+  );
+
   it('lets an embedder override a required translation', () => {
     expect(
       getTranslation('send_message', 'fr', {

--- a/packages/core/src/__tests__/translation.spec.ts
+++ b/packages/core/src/__tests__/translation.spec.ts
@@ -49,18 +49,36 @@ describe('translations', () => {
     'support_chat_aria_label',
   ] satisfies TranslationKeyU[];
 
-  it.each(['ar', 'ja', 'ru'] as const)(
+  /**
+   * `language.key` pairs whose translation is genuinely the English word, so
+   * the sweep below does not report them. Keep this list short and explicit —
+   * every entry is a claim that a native speaker would write it this way.
+   */
+  const sharedWithEnglish = new Set([
+    // "No" is the Spanish and Italian word too.
+    'es.close_conversation_cancel',
+    'it.close_conversation_cancel',
+  ]);
+
+  it('recognizes English copy as English', () => {
+    // Positive control for the per-language sweep: prove the comparison fires
+    // when the copy really is English, so an empty result there means
+    // "everything was translated" rather than "nothing was compared".
+    expect(previouslyHardcoded).toHaveLength(9);
+    expect(
+      previouslyHardcoded.filter(
+        (key) => getTranslation(key, 'en', undefined) === EnglishLanguage[key],
+      ),
+    ).toEqual(previouslyHardcoded);
+  });
+
+  it.each(LANGUAGES.filter((language) => language !== 'en'))(
     '%s localizes the labels that used to be hardcoded',
     (language) => {
-      // Positive control: this locale really is being read, so a failure below
-      // means untranslated copy rather than a broken lookup.
-      expect(getTranslation('close_conversation_cancel', 'ar', undefined)).toBe(
-        'لا',
-      );
-
       const stillEnglish = previouslyHardcoded.filter(
         (key) =>
-          getTranslation(key, language, undefined) === EnglishLanguage[key],
+          getTranslation(key, language, undefined) === EnglishLanguage[key] &&
+          !sharedWithEnglish.has(`${language}.${key}`),
       );
 
       expect(stillEnglish).toEqual([]);

--- a/packages/core/src/translation/ar.ts
+++ b/packages/core/src/translation/ar.ts
@@ -102,4 +102,13 @@ export const ArabicLanguage: TranslationInterface = {
   questions_send: 'إرسال',
   questions_type_answer: 'سأكتبها بنفسي',
   questions_answer_placeholder: 'اكتب إجابتك…',
+  close_conversation_title: 'إغلاق المحادثة',
+  close_conversation_description: 'هل أنت متأكد أنك تريد إغلاق هذه المحادثة؟',
+  close_conversation_cancel: 'لا',
+  close_conversation_confirm: 'نعم',
+  dialog_close: 'إغلاق',
+  zoom_in: 'تكبير',
+  zoom_out: 'تصغير',
+  reset_zoom: 'إعادة تعيين التكبير',
+  support_chat_aria_label: 'دردشة الدعم',
 };

--- a/packages/core/src/translation/bg.ts
+++ b/packages/core/src/translation/bg.ts
@@ -91,4 +91,14 @@ export const BulgarianLanguage: TranslationInterface = {
   questions_send: 'Изпрати',
   questions_type_answer: 'Ще напиша сам',
   questions_answer_placeholder: 'Напишете отговора си…',
+  close_conversation_title: 'Затваряне на разговора',
+  close_conversation_description:
+    'Сигурни ли сте, че искате да затворите този разговор?',
+  close_conversation_cancel: 'Не',
+  close_conversation_confirm: 'Да',
+  dialog_close: 'Затваряне',
+  zoom_in: 'Увеличаване',
+  zoom_out: 'Намаляване',
+  reset_zoom: 'Нулиране на мащаба',
+  support_chat_aria_label: 'Чат за поддръжка',
 };

--- a/packages/core/src/translation/bn.ts
+++ b/packages/core/src/translation/bn.ts
@@ -91,4 +91,14 @@ export const BengaliLanguage: TranslationInterface = {
   questions_send: 'পাঠান',
   questions_type_answer: 'আমি লিখে দিচ্ছি',
   questions_answer_placeholder: 'আপনার উত্তর লিখুন…',
+  close_conversation_title: 'কথোপকথন বন্ধ করুন',
+  close_conversation_description:
+    'আপনি কি নিশ্চিত যে আপনি এই কথোপকথনটি বন্ধ করতে চান?',
+  close_conversation_cancel: 'না',
+  close_conversation_confirm: 'হ্যাঁ',
+  dialog_close: 'বন্ধ করুন',
+  zoom_in: 'বড় করুন',
+  zoom_out: 'ছোট করুন',
+  reset_zoom: 'জুম রিসেট করুন',
+  support_chat_aria_label: 'সাপোর্ট চ্যাট',
 };

--- a/packages/core/src/translation/cs.ts
+++ b/packages/core/src/translation/cs.ts
@@ -91,4 +91,13 @@ export const CzechLanguage: TranslationInterface = {
   questions_send: 'Odeslat',
   questions_type_answer: 'Napíšu to sám',
   questions_answer_placeholder: 'Napište svou odpověď…',
+  close_conversation_title: 'Uzavřít konverzaci',
+  close_conversation_description: 'Opravdu chcete tuto konverzaci uzavřít?',
+  close_conversation_cancel: 'Ne',
+  close_conversation_confirm: 'Ano',
+  dialog_close: 'Zavřít',
+  zoom_in: 'Přiblížit',
+  zoom_out: 'Oddálit',
+  reset_zoom: 'Obnovit přiblížení',
+  support_chat_aria_label: 'Chat podpory',
 };

--- a/packages/core/src/translation/da.ts
+++ b/packages/core/src/translation/da.ts
@@ -91,4 +91,14 @@ export const DanishLanguage: TranslationInterface = {
   questions_send: 'Send',
   questions_type_answer: 'Jeg skriver det selv',
   questions_answer_placeholder: 'Skriv dit svar…',
+  close_conversation_title: 'Luk samtale',
+  close_conversation_description:
+    'Er du sikker på, at du vil lukke denne samtale?',
+  close_conversation_cancel: 'Nej',
+  close_conversation_confirm: 'Ja',
+  dialog_close: 'Luk',
+  zoom_in: 'Zoom ind',
+  zoom_out: 'Zoom ud',
+  reset_zoom: 'Nulstil zoom',
+  support_chat_aria_label: 'Supportchat',
 };

--- a/packages/core/src/translation/de.ts
+++ b/packages/core/src/translation/de.ts
@@ -93,4 +93,14 @@ export const GermanLanguage: TranslationInterface = {
   questions_send: 'Senden',
   questions_type_answer: 'Ich schreibe es selbst',
   questions_answer_placeholder: 'Antwort eingeben…',
+  close_conversation_title: 'Konversation schließen',
+  close_conversation_description:
+    'Möchten Sie diese Konversation wirklich schließen?',
+  close_conversation_cancel: 'Nein',
+  close_conversation_confirm: 'Ja',
+  dialog_close: 'Schließen',
+  zoom_in: 'Vergrößern',
+  zoom_out: 'Verkleinern',
+  reset_zoom: 'Zoom zurücksetzen',
+  support_chat_aria_label: 'Support-Chat',
 };

--- a/packages/core/src/translation/el.ts
+++ b/packages/core/src/translation/el.ts
@@ -92,4 +92,14 @@ export const GreekLanguage: TranslationInterface = {
   questions_send: 'Αποστολή',
   questions_type_answer: 'Θα το γράψω',
   questions_answer_placeholder: 'Γράψτε την απάντησή σας…',
+  close_conversation_title: 'Κλείσιμο συνομιλίας',
+  close_conversation_description:
+    'Είστε βέβαιοι ότι θέλετε να κλείσετε αυτήν τη συνομιλία;',
+  close_conversation_cancel: 'Όχι',
+  close_conversation_confirm: 'Ναι',
+  dialog_close: 'Κλείσιμο',
+  zoom_in: 'Μεγέθυνση',
+  zoom_out: 'Σμίκρυνση',
+  reset_zoom: 'Επαναφορά ζουμ',
+  support_chat_aria_label: 'Συνομιλία υποστήριξης',
 };

--- a/packages/core/src/translation/en.ts
+++ b/packages/core/src/translation/en.ts
@@ -102,4 +102,14 @@ export const EnglishLanguage: TranslationInterface = {
   questions_send: 'Send',
   questions_type_answer: "I'll type it",
   questions_answer_placeholder: 'Type your answer…',
+  close_conversation_title: 'Close conversation',
+  close_conversation_description:
+    'Are you sure you want to close this conversation?',
+  close_conversation_cancel: 'No',
+  close_conversation_confirm: 'Yes',
+  dialog_close: 'Close',
+  zoom_in: 'Zoom in',
+  zoom_out: 'Zoom out',
+  reset_zoom: 'Reset zoom',
+  support_chat_aria_label: 'Support chat',
 };

--- a/packages/core/src/translation/es.ts
+++ b/packages/core/src/translation/es.ts
@@ -92,4 +92,14 @@ export const SpanishLanguage: TranslationInterface = {
   questions_send: 'Enviar',
   questions_type_answer: 'Lo escribo yo',
   questions_answer_placeholder: 'Escribe tu respuesta…',
+  close_conversation_title: 'Cerrar conversación',
+  close_conversation_description:
+    '¿Seguro que quieres cerrar esta conversación?',
+  close_conversation_cancel: 'No',
+  close_conversation_confirm: 'Sí',
+  dialog_close: 'Cerrar',
+  zoom_in: 'Acercar',
+  zoom_out: 'Alejar',
+  reset_zoom: 'Restablecer zoom',
+  support_chat_aria_label: 'Chat de soporte',
 };

--- a/packages/core/src/translation/et.ts
+++ b/packages/core/src/translation/et.ts
@@ -91,4 +91,14 @@ export const EstonianLanguage: TranslationInterface = {
   questions_send: 'Saada',
   questions_type_answer: 'Kirjutan ise',
   questions_answer_placeholder: 'Kirjutage oma vastus…',
+  close_conversation_title: 'Sulge vestlus',
+  close_conversation_description:
+    'Kas soovite kindlasti selle vestluse sulgeda?',
+  close_conversation_cancel: 'Ei',
+  close_conversation_confirm: 'Jah',
+  dialog_close: 'Sulge',
+  zoom_in: 'Suurenda',
+  zoom_out: 'Vähenda',
+  reset_zoom: 'Lähtesta suurendus',
+  support_chat_aria_label: 'Tugivestlus',
 };

--- a/packages/core/src/translation/fi.ts
+++ b/packages/core/src/translation/fi.ts
@@ -91,4 +91,13 @@ export const FinnishLanguage: TranslationInterface = {
   questions_send: 'Lähetä',
   questions_type_answer: 'Kirjoitan itse',
   questions_answer_placeholder: 'Kirjoita vastauksesi…',
+  close_conversation_title: 'Sulje keskustelu',
+  close_conversation_description: 'Haluatko varmasti sulkea tämän keskustelun?',
+  close_conversation_cancel: 'Ei',
+  close_conversation_confirm: 'Kyllä',
+  dialog_close: 'Sulje',
+  zoom_in: 'Lähennä',
+  zoom_out: 'Loitonna',
+  reset_zoom: 'Palauta zoomaus',
+  support_chat_aria_label: 'Tukichat',
 };

--- a/packages/core/src/translation/fil.ts
+++ b/packages/core/src/translation/fil.ts
@@ -91,4 +91,14 @@ export const FilipinoLanguage: TranslationInterface = {
   questions_send: 'Ipadala',
   questions_type_answer: 'Ako na ang magta-type',
   questions_answer_placeholder: 'I-type ang iyong sagot…',
+  close_conversation_title: 'Isara ang usapan',
+  close_conversation_description:
+    'Sigurado ka bang gusto mong isara ang usapang ito?',
+  close_conversation_cancel: 'Hindi',
+  close_conversation_confirm: 'Oo',
+  dialog_close: 'Isara',
+  zoom_in: 'Palakihin',
+  zoom_out: 'Paliitin',
+  reset_zoom: 'I-reset ang zoom',
+  support_chat_aria_label: 'Support chat',
 };

--- a/packages/core/src/translation/fil.ts
+++ b/packages/core/src/translation/fil.ts
@@ -100,5 +100,5 @@ export const FilipinoLanguage: TranslationInterface = {
   zoom_in: 'Palakihin',
   zoom_out: 'Paliitin',
   reset_zoom: 'I-reset ang zoom',
-  support_chat_aria_label: 'Support chat',
+  support_chat_aria_label: 'Chat ng suporta',
 };

--- a/packages/core/src/translation/fr.ts
+++ b/packages/core/src/translation/fr.ts
@@ -94,4 +94,14 @@ export const FrenchLanguage: TranslationInterface = {
   questions_send: 'Envoyer',
   questions_type_answer: 'Je préfère écrire',
   questions_answer_placeholder: 'Écrivez votre réponse…',
+  close_conversation_title: 'Fermer la conversation',
+  close_conversation_description:
+    'Voulez-vous vraiment fermer cette conversation ?',
+  close_conversation_cancel: 'Non',
+  close_conversation_confirm: 'Oui',
+  dialog_close: 'Fermer',
+  zoom_in: 'Zoom avant',
+  zoom_out: 'Zoom arrière',
+  reset_zoom: 'Réinitialiser le zoom',
+  support_chat_aria_label: 'Chat de support',
 };

--- a/packages/core/src/translation/hi.ts
+++ b/packages/core/src/translation/hi.ts
@@ -91,4 +91,14 @@ export const HindiLanguage: TranslationInterface = {
   questions_send: 'भेजें',
   questions_type_answer: 'मैं खुद लिखूंगा',
   questions_answer_placeholder: 'अपना उत्तर लिखें…',
+  close_conversation_title: 'बातचीत बंद करें',
+  close_conversation_description:
+    'क्या आप वाकई इस बातचीत को बंद करना चाहते हैं?',
+  close_conversation_cancel: 'नहीं',
+  close_conversation_confirm: 'हाँ',
+  dialog_close: 'बंद करें',
+  zoom_in: 'ज़ूम इन',
+  zoom_out: 'ज़ूम आउट',
+  reset_zoom: 'ज़ूम रीसेट करें',
+  support_chat_aria_label: 'सहायता चैट',
 };

--- a/packages/core/src/translation/hr.ts
+++ b/packages/core/src/translation/hr.ts
@@ -91,4 +91,14 @@ export const CroatianLanguage: TranslationInterface = {
   questions_send: 'Pošalji',
   questions_type_answer: 'Napisat ću sam',
   questions_answer_placeholder: 'Napišite svoj odgovor…',
+  close_conversation_title: 'Zatvori razgovor',
+  close_conversation_description:
+    'Jeste li sigurni da želite zatvoriti ovaj razgovor?',
+  close_conversation_cancel: 'Ne',
+  close_conversation_confirm: 'Da',
+  dialog_close: 'Zatvori',
+  zoom_in: 'Približi',
+  zoom_out: 'Udalji',
+  reset_zoom: 'Poništi zumiranje',
+  support_chat_aria_label: 'Chat za podršku',
 };

--- a/packages/core/src/translation/hu.ts
+++ b/packages/core/src/translation/hu.ts
@@ -91,4 +91,13 @@ export const HungarianLanguage: TranslationInterface = {
   questions_send: 'Küldés',
   questions_type_answer: 'Inkább leírom',
   questions_answer_placeholder: 'Írja le a válaszát…',
+  close_conversation_title: 'Beszélgetés lezárása',
+  close_conversation_description: 'Biztosan lezárja ezt a beszélgetést?',
+  close_conversation_cancel: 'Nem',
+  close_conversation_confirm: 'Igen',
+  dialog_close: 'Bezárás',
+  zoom_in: 'Nagyítás',
+  zoom_out: 'Kicsinyítés',
+  reset_zoom: 'Nagyítás visszaállítása',
+  support_chat_aria_label: 'Ügyfélszolgálati chat',
 };

--- a/packages/core/src/translation/index.ts
+++ b/packages/core/src/translation/index.ts
@@ -243,5 +243,17 @@ export type TranslationInterface = {
   questions_type_answer: string;
   /** Placeholder of that free-text answer box. */
   questions_answer_placeholder: string;
+  /** Fallbacks for the close-session confirmation; a header button's own copy wins. */
+  close_conversation_title: string;
+  close_conversation_description: string;
+  close_conversation_cancel: string;
+  close_conversation_confirm: string;
+  /** Screen-reader label of the modal's corner dismiss button. */
+  dialog_close: string;
+  zoom_in: string;
+  zoom_out: string;
+  reset_zoom: string;
+  /** Names the chat panel for screen readers on the host page. */
+  support_chat_aria_label: string;
 };
 export type TranslationKeyU = keyof TranslationInterface;

--- a/packages/core/src/translation/is.ts
+++ b/packages/core/src/translation/is.ts
@@ -91,4 +91,14 @@ export const IcelandicLanguage: TranslationInterface = {
   questions_send: 'Senda',
   questions_type_answer: 'Ég skrifa það',
   questions_answer_placeholder: 'Skrifaðu svarið þitt…',
+  close_conversation_title: 'Loka samtali',
+  close_conversation_description:
+    'Ertu viss um að þú viljir loka þessu samtali?',
+  close_conversation_cancel: 'Nei',
+  close_conversation_confirm: 'Já',
+  dialog_close: 'Loka',
+  zoom_in: 'Auka aðdrátt',
+  zoom_out: 'Minnka aðdrátt',
+  reset_zoom: 'Endurstilla aðdrátt',
+  support_chat_aria_label: 'Þjónustuspjall',
 };

--- a/packages/core/src/translation/it.ts
+++ b/packages/core/src/translation/it.ts
@@ -93,4 +93,13 @@ export const ItalianLanguage: TranslationInterface = {
   questions_send: 'Invia',
   questions_type_answer: 'Lo scrivo io',
   questions_answer_placeholder: 'Scrivi la tua risposta…',
+  close_conversation_title: 'Chiudi conversazione',
+  close_conversation_description: 'Vuoi davvero chiudere questa conversazione?',
+  close_conversation_cancel: 'No',
+  close_conversation_confirm: 'Sì',
+  dialog_close: 'Chiudi',
+  zoom_in: 'Ingrandisci',
+  zoom_out: 'Riduci',
+  reset_zoom: 'Reimposta zoom',
+  support_chat_aria_label: 'Chat di supporto',
 };

--- a/packages/core/src/translation/ja.ts
+++ b/packages/core/src/translation/ja.ts
@@ -89,4 +89,13 @@ export const JapaneseLanguage: TranslationInterface = {
   questions_send: '送信',
   questions_type_answer: '自分で入力する',
   questions_answer_placeholder: '回答を入力してください…',
+  close_conversation_title: '会話を終了',
+  close_conversation_description: 'この会話を終了してもよろしいですか？',
+  close_conversation_cancel: 'いいえ',
+  close_conversation_confirm: 'はい',
+  dialog_close: '閉じる',
+  zoom_in: '拡大',
+  zoom_out: '縮小',
+  reset_zoom: 'ズームをリセット',
+  support_chat_aria_label: 'サポートチャット',
 };

--- a/packages/core/src/translation/ko.ts
+++ b/packages/core/src/translation/ko.ts
@@ -90,4 +90,13 @@ export const KoreanLanguage: TranslationInterface = {
   questions_send: '보내기',
   questions_type_answer: '직접 입력할게요',
   questions_answer_placeholder: '답변을 입력하세요…',
+  close_conversation_title: '대화 종료',
+  close_conversation_description: '이 대화를 종료하시겠습니까?',
+  close_conversation_cancel: '아니요',
+  close_conversation_confirm: '예',
+  dialog_close: '닫기',
+  zoom_in: '확대',
+  zoom_out: '축소',
+  reset_zoom: '확대/축소 초기화',
+  support_chat_aria_label: '고객 지원 채팅',
 };

--- a/packages/core/src/translation/lb.ts
+++ b/packages/core/src/translation/lb.ts
@@ -92,4 +92,14 @@ export const LuxembourgishLanguage: TranslationInterface = {
   questions_send: 'Schécken',
   questions_type_answer: 'Ech schreiwen et selwer',
   questions_answer_placeholder: 'Schreift Är Äntwert…',
+  close_conversation_title: 'Konversatioun zoumaachen',
+  close_conversation_description:
+    'Wëllt Dir dës Konversatioun wierklech zoumaachen?',
+  close_conversation_cancel: 'Nee',
+  close_conversation_confirm: 'Jo',
+  dialog_close: 'Zoumaachen',
+  zoom_in: 'Erazoomen',
+  zoom_out: 'Erauszoomen',
+  reset_zoom: 'Zoom zrécksetzen',
+  support_chat_aria_label: 'Support-Chat',
 };

--- a/packages/core/src/translation/lt.ts
+++ b/packages/core/src/translation/lt.ts
@@ -91,4 +91,13 @@ export const LithuanianLanguage: TranslationInterface = {
   questions_send: 'Siųsti',
   questions_type_answer: 'Parašysiu pats',
   questions_answer_placeholder: 'Parašykite savo atsakymą…',
+  close_conversation_title: 'Uždaryti pokalbį',
+  close_conversation_description: 'Ar tikrai norite uždaryti šį pokalbį?',
+  close_conversation_cancel: 'Ne',
+  close_conversation_confirm: 'Taip',
+  dialog_close: 'Uždaryti',
+  zoom_in: 'Priartinti',
+  zoom_out: 'Nutolinti',
+  reset_zoom: 'Atstatyti mastelį',
+  support_chat_aria_label: 'Pagalbos pokalbis',
 };

--- a/packages/core/src/translation/lv.ts
+++ b/packages/core/src/translation/lv.ts
@@ -91,4 +91,13 @@ export const LatvianLanguage: TranslationInterface = {
   questions_send: 'Sūtīt',
   questions_type_answer: 'Rakstīšu pats',
   questions_answer_placeholder: 'Ierakstiet savu atbildi…',
+  close_conversation_title: 'Aizvērt sarunu',
+  close_conversation_description: 'Vai tiešām vēlaties aizvērt šo sarunu?',
+  close_conversation_cancel: 'Nē',
+  close_conversation_confirm: 'Jā',
+  dialog_close: 'Aizvērt',
+  zoom_in: 'Pietuvināt',
+  zoom_out: 'Attālināt',
+  reset_zoom: 'Atiestatīt tālummaiņu',
+  support_chat_aria_label: 'Atbalsta tērzēšana',
 };

--- a/packages/core/src/translation/mt.ts
+++ b/packages/core/src/translation/mt.ts
@@ -92,4 +92,13 @@ export const MalteseLanguage: TranslationInterface = {
   questions_send: 'Ibgħat',
   questions_type_answer: 'Nikteb jien',
   questions_answer_placeholder: 'Ikteb it-tweġiba tiegħek…',
+  close_conversation_title: 'Agħlaq il-konversazzjoni',
+  close_conversation_description: 'Żgur li trid tagħlaq din il-konversazzjoni?',
+  close_conversation_cancel: 'Le',
+  close_conversation_confirm: 'Iva',
+  dialog_close: 'Agħlaq',
+  zoom_in: 'Kabbar',
+  zoom_out: 'Ċekken',
+  reset_zoom: 'Irrisettja ż-zoom',
+  support_chat_aria_label: 'Chat ta’ appoġġ',
 };

--- a/packages/core/src/translation/nb.ts
+++ b/packages/core/src/translation/nb.ts
@@ -91,4 +91,14 @@ export const NorwegianBokmalLanguage: TranslationInterface = {
   questions_send: 'Send',
   questions_type_answer: 'Jeg skriver det selv',
   questions_answer_placeholder: 'Skriv svaret ditt…',
+  close_conversation_title: 'Lukk samtale',
+  close_conversation_description:
+    'Er du sikker på at du vil lukke denne samtalen?',
+  close_conversation_cancel: 'Nei',
+  close_conversation_confirm: 'Ja',
+  dialog_close: 'Lukk',
+  zoom_in: 'Zoom inn',
+  zoom_out: 'Zoom ut',
+  reset_zoom: 'Tilbakestill zoom',
+  support_chat_aria_label: 'Support-chat',
 };

--- a/packages/core/src/translation/nl.ts
+++ b/packages/core/src/translation/nl.ts
@@ -92,4 +92,14 @@ export const DutchLanguage: TranslationInterface = {
   questions_send: 'Verzenden',
   questions_type_answer: 'Ik typ het zelf',
   questions_answer_placeholder: 'Typ je antwoord…',
+  close_conversation_title: 'Gesprek sluiten',
+  close_conversation_description:
+    'Weet je zeker dat je dit gesprek wilt sluiten?',
+  close_conversation_cancel: 'Nee',
+  close_conversation_confirm: 'Ja',
+  dialog_close: 'Sluiten',
+  zoom_in: 'Inzoomen',
+  zoom_out: 'Uitzoomen',
+  reset_zoom: 'Zoom herstellen',
+  support_chat_aria_label: 'Supportchat',
 };

--- a/packages/core/src/translation/no.ts
+++ b/packages/core/src/translation/no.ts
@@ -91,4 +91,14 @@ export const NorwegianLanguage: TranslationInterface = {
   questions_send: 'Send',
   questions_type_answer: 'Jeg skriver det selv',
   questions_answer_placeholder: 'Skriv svaret ditt…',
+  close_conversation_title: 'Lukk samtale',
+  close_conversation_description:
+    'Er du sikker på at du vil lukke denne samtalen?',
+  close_conversation_cancel: 'Nei',
+  close_conversation_confirm: 'Ja',
+  dialog_close: 'Lukk',
+  zoom_in: 'Zoom inn',
+  zoom_out: 'Zoom ut',
+  reset_zoom: 'Tilbakestill zoom',
+  support_chat_aria_label: 'Support-chat',
 };

--- a/packages/core/src/translation/pl.ts
+++ b/packages/core/src/translation/pl.ts
@@ -91,4 +91,13 @@ export const PolishLanguage: TranslationInterface = {
   questions_send: 'Wyślij',
   questions_type_answer: 'Napiszę sam',
   questions_answer_placeholder: 'Wpisz swoją odpowiedź…',
+  close_conversation_title: 'Zamknij rozmowę',
+  close_conversation_description: 'Czy na pewno chcesz zamknąć tę rozmowę?',
+  close_conversation_cancel: 'Nie',
+  close_conversation_confirm: 'Tak',
+  dialog_close: 'Zamknij',
+  zoom_in: 'Powiększ',
+  zoom_out: 'Pomniejsz',
+  reset_zoom: 'Resetuj powiększenie',
+  support_chat_aria_label: 'Czat pomocy',
 };

--- a/packages/core/src/translation/pt.ts
+++ b/packages/core/src/translation/pt.ts
@@ -92,4 +92,14 @@ export const PortugueseLanguage: TranslationInterface = {
   questions_send: 'Enviar',
   questions_type_answer: 'Prefiro escrever',
   questions_answer_placeholder: 'Escreva a sua resposta…',
+  close_conversation_title: 'Encerrar conversa',
+  close_conversation_description:
+    'Tem certeza de que deseja encerrar esta conversa?',
+  close_conversation_cancel: 'Não',
+  close_conversation_confirm: 'Sim',
+  dialog_close: 'Fechar',
+  zoom_in: 'Ampliar',
+  zoom_out: 'Reduzir',
+  reset_zoom: 'Redefinir zoom',
+  support_chat_aria_label: 'Chat de suporte',
 };

--- a/packages/core/src/translation/ro.ts
+++ b/packages/core/src/translation/ro.ts
@@ -92,4 +92,13 @@ export const RomanianLanguage: TranslationInterface = {
   questions_send: 'Trimite',
   questions_type_answer: 'Scriu eu',
   questions_answer_placeholder: 'Scrieți răspunsul dvs.…',
+  close_conversation_title: 'Închide conversația',
+  close_conversation_description: 'Sigur vrei să închizi această conversație?',
+  close_conversation_cancel: 'Nu',
+  close_conversation_confirm: 'Da',
+  dialog_close: 'Închide',
+  zoom_in: 'Mărește',
+  zoom_out: 'Micșorează',
+  reset_zoom: 'Resetează zoomul',
+  support_chat_aria_label: 'Chat de asistență',
 };

--- a/packages/core/src/translation/ru.ts
+++ b/packages/core/src/translation/ru.ts
@@ -91,4 +91,14 @@ export const RussianLanguage: TranslationInterface = {
   questions_send: 'Отправить',
   questions_type_answer: 'Напишу сам',
   questions_answer_placeholder: 'Напишите ваш ответ…',
+  close_conversation_title: 'Закрыть разговор',
+  close_conversation_description:
+    'Вы уверены, что хотите закрыть этот разговор?',
+  close_conversation_cancel: 'Нет',
+  close_conversation_confirm: 'Да',
+  dialog_close: 'Закрыть',
+  zoom_in: 'Увеличить',
+  zoom_out: 'Уменьшить',
+  reset_zoom: 'Сбросить масштаб',
+  support_chat_aria_label: 'Чат поддержки',
 };

--- a/packages/core/src/translation/sk.ts
+++ b/packages/core/src/translation/sk.ts
@@ -91,4 +91,13 @@ export const SlovakLanguage: TranslationInterface = {
   questions_send: 'Odoslať',
   questions_type_answer: 'Napíšem to sám',
   questions_answer_placeholder: 'Napíšte svoju odpoveď…',
+  close_conversation_title: 'Uzavrieť konverzáciu',
+  close_conversation_description: 'Naozaj chcete túto konverzáciu uzavrieť?',
+  close_conversation_cancel: 'Nie',
+  close_conversation_confirm: 'Áno',
+  dialog_close: 'Zavrieť',
+  zoom_in: 'Priblížiť',
+  zoom_out: 'Oddialiť',
+  reset_zoom: 'Obnoviť priblíženie',
+  support_chat_aria_label: 'Chat podpory',
 };

--- a/packages/core/src/translation/sv.ts
+++ b/packages/core/src/translation/sv.ts
@@ -91,4 +91,14 @@ export const SwedishLanguage: TranslationInterface = {
   questions_send: 'Skicka',
   questions_type_answer: 'Jag skriver själv',
   questions_answer_placeholder: 'Skriv ditt svar…',
+  close_conversation_title: 'Avsluta konversation',
+  close_conversation_description:
+    'Är du säker på att du vill avsluta den här konversationen?',
+  close_conversation_cancel: 'Nej',
+  close_conversation_confirm: 'Ja',
+  dialog_close: 'Stäng',
+  zoom_in: 'Zooma in',
+  zoom_out: 'Zooma ut',
+  reset_zoom: 'Återställ zoom',
+  support_chat_aria_label: 'Supportchatt',
 };

--- a/packages/core/src/translation/th.ts
+++ b/packages/core/src/translation/th.ts
@@ -90,4 +90,13 @@ export const ThaiLanguage: TranslationInterface = {
   questions_send: 'ส่ง',
   questions_type_answer: 'ขอพิมพ์เอง',
   questions_answer_placeholder: 'พิมพ์คำตอบของคุณ…',
+  close_conversation_title: 'ปิดการสนทนา',
+  close_conversation_description: 'คุณแน่ใจหรือไม่ว่าต้องการปิดการสนทนานี้?',
+  close_conversation_cancel: 'ไม่',
+  close_conversation_confirm: 'ใช่',
+  dialog_close: 'ปิด',
+  zoom_in: 'ขยาย',
+  zoom_out: 'ย่อ',
+  reset_zoom: 'รีเซ็ตการซูม',
+  support_chat_aria_label: 'แชทฝ่ายสนับสนุน',
 };

--- a/packages/core/src/translation/tr.ts
+++ b/packages/core/src/translation/tr.ts
@@ -91,4 +91,14 @@ export const TurkishLanguage: TranslationInterface = {
   questions_send: 'Gönder',
   questions_type_answer: 'Kendim yazayım',
   questions_answer_placeholder: 'Yanıtınızı yazın…',
+  close_conversation_title: 'Görüşmeyi kapat',
+  close_conversation_description:
+    'Bu görüşmeyi kapatmak istediğinizden emin misiniz?',
+  close_conversation_cancel: 'Hayır',
+  close_conversation_confirm: 'Evet',
+  dialog_close: 'Kapat',
+  zoom_in: 'Yakınlaştır',
+  zoom_out: 'Uzaklaştır',
+  reset_zoom: 'Yakınlaştırmayı sıfırla',
+  support_chat_aria_label: 'Destek sohbeti',
 };

--- a/packages/core/src/translation/ur.ts
+++ b/packages/core/src/translation/ur.ts
@@ -91,4 +91,13 @@ export const UrduLanguage: TranslationInterface = {
   questions_send: 'بھیجیں',
   questions_type_answer: 'میں خود لکھوں گا',
   questions_answer_placeholder: 'اپنا جواب لکھیں…',
+  close_conversation_title: 'گفتگو بند کریں',
+  close_conversation_description: 'کیا آپ واقعی یہ گفتگو بند کرنا چاہتے ہیں؟',
+  close_conversation_cancel: 'نہیں',
+  close_conversation_confirm: 'ہاں',
+  dialog_close: 'بند کریں',
+  zoom_in: 'زوم اِن',
+  zoom_out: 'زوم آؤٹ',
+  reset_zoom: 'زوم دوبارہ ترتیب دیں',
+  support_chat_aria_label: 'سپورٹ چیٹ',
 };

--- a/packages/core/src/translation/vi.ts
+++ b/packages/core/src/translation/vi.ts
@@ -91,4 +91,14 @@ export const VietnameseLanguage: TranslationInterface = {
   questions_send: 'Gửi',
   questions_type_answer: 'Tôi sẽ tự nhập',
   questions_answer_placeholder: 'Nhập câu trả lời của bạn…',
+  close_conversation_title: 'Đóng cuộc trò chuyện',
+  close_conversation_description:
+    'Bạn có chắc muốn đóng cuộc trò chuyện này không?',
+  close_conversation_cancel: 'Không',
+  close_conversation_confirm: 'Có',
+  dialog_close: 'Đóng',
+  zoom_in: 'Phóng to',
+  zoom_out: 'Thu nhỏ',
+  reset_zoom: 'Đặt lại thu phóng',
+  support_chat_aria_label: 'Trò chuyện hỗ trợ',
 };

--- a/packages/core/src/translation/zh-cn.ts
+++ b/packages/core/src/translation/zh-cn.ts
@@ -89,4 +89,13 @@ export const ChineseSimplifiedLanguage: TranslationInterface = {
   questions_send: '发送',
   questions_type_answer: '我自己输入',
   questions_answer_placeholder: '输入你的回答…',
+  close_conversation_title: '结束对话',
+  close_conversation_description: '确定要结束此对话吗？',
+  close_conversation_cancel: '否',
+  close_conversation_confirm: '是',
+  dialog_close: '关闭',
+  zoom_in: '放大',
+  zoom_out: '缩小',
+  reset_zoom: '重置缩放',
+  support_chat_aria_label: '支持对话',
 };

--- a/packages/react/src/WidgetPopoverContent.tsx
+++ b/packages/react/src/WidgetPopoverContent.tsx
@@ -15,6 +15,7 @@ import {
 } from './components/FrameDocument';
 import { MORPH_SPRING } from './motion';
 import { useTheme } from './hooks/useTheme';
+import { useTranslation } from './hooks/useTranslation';
 import { RootScreen } from './screens';
 
 const initialContent = buildFrameHtml();
@@ -101,6 +102,7 @@ export function WidgetContent() {
 export function WidgetPopoverContent() {
   const { theme, triggerSide } = useTheme();
   const { dir: hostDocumentDir } = useDocumentDir();
+  const { t } = useTranslation();
 
   // Radix/floating-ui resolves `align` logically against the floating element's
   // computed direction (inherited from the host page via the portal): on an RTL
@@ -123,7 +125,7 @@ export function WidgetPopoverContent() {
       side="top"
       align={align}
       aria-modal="false"
-      aria-label="Support chat"
+      aria-label={t('support_chat_aria_label')}
       sideOffset={theme.widgetContentContainer.offset.side}
       alignOffset={theme.widgetContentContainer.offset.align}
       avoidCollisions={false}

--- a/packages/react/src/components/Dialoger.tsx
+++ b/packages/react/src/components/Dialoger.tsx
@@ -13,6 +13,7 @@ import { Button } from './lib/button';
 import { X } from 'lucide-react';
 import { useWidget } from '@opencx/widget-react-headless';
 import { log } from '@opencx/widget-core';
+import { useTranslation } from '../hooks/useTranslation';
 
 interface DialogerProviderValue {
   open: (content: React.ReactNode) => void;
@@ -117,6 +118,7 @@ export function DialogerContent({
   withClose?: boolean;
 }) {
   const { close } = useDialoger();
+  const { t } = useTranslation();
   return (
     <div
       data-opencx-escape-scope
@@ -134,7 +136,7 @@ export function DialogerContent({
           onClick={close}
         >
           <X className="h-4 w-4" />
-          <span className="sr-only">Close</span>
+          <span className="sr-only">{t('dialog_close')}</span>
         </Button>
       )}
     </div>

--- a/packages/react/src/components/Header.tsx
+++ b/packages/react/src/components/Header.tsx
@@ -19,6 +19,7 @@ import { useComponentContext } from '../hooks/useComponentContext';
 import { useIsSmallScreen } from '../hooks/useIsSmallScreen';
 import { useSetWidgetSizeFn } from '../hooks/useSetWidgetSize';
 import { useTheme } from '../hooks/useTheme';
+import { useTranslation } from '../hooks/useTranslation';
 import { dc } from '../utils/data-component';
 import {
   Dialoger,
@@ -221,6 +222,7 @@ function Header__Buttons__Item__ResolveSession({
   const { resolveSession, sessionState } = useSessions();
   const { isSmallScreen } = useIsSmallScreen();
   const componentCtx = useComponentContext();
+  const { t } = useTranslation();
 
   const isNoSession = !sessionState.session;
   const isResolved = sessionState.session?.isOpened === false;
@@ -333,13 +335,13 @@ function Header__Buttons__Item__ResolveSession({
         <DialogerContent>
           <DialogerHeader>
             <DialogerTitle>
-              {button.confirmation.title || 'Close conversation'}
+              {button.confirmation.title || t('close_conversation_title')}
             </DialogerTitle>
           </DialogerHeader>
           <DialogerBody>
             <DialogerDescription>
               {button.confirmation.description ||
-                'Are you sure you want to close this conversation?'}
+                t('close_conversation_description')}
             </DialogerDescription>
           </DialogerBody>
           <DialogerFooter>
@@ -348,7 +350,8 @@ function Header__Buttons__Item__ResolveSession({
               onClick={closeDialog}
               disabled={sessionState.isResolvingSession}
             >
-              {button.confirmation.cancelButtonText || 'No'}
+              {button.confirmation.cancelButtonText ||
+                t('close_conversation_cancel')}
             </Button>
             <Button
               variant="destructive"
@@ -358,7 +361,8 @@ function Header__Buttons__Item__ResolveSession({
               }}
               disabled={sessionState.isResolvingSession}
             >
-              {button.confirmation.confirmButtonText || 'Yes'}
+              {button.confirmation.confirmButtonText ||
+                t('close_conversation_confirm')}
             </Button>
           </DialogerFooter>
         </DialogerContent>

--- a/packages/react/src/components/ZoomableImage.tsx
+++ b/packages/react/src/components/ZoomableImage.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useRef, useState } from 'react';
 import { ZoomIn, ZoomOut, RotateCcw } from 'lucide-react';
 import { cn } from './lib/utils/cn';
+import { useTranslation } from '../hooks/useTranslation';
 
 const MIN_SCALE = 1;
 const MAX_SCALE = 5;
@@ -31,6 +32,7 @@ function clampTranslate(
 }
 
 export function ZoomableImage({ src, alt }: { src: string; alt?: string }) {
+  const { t } = useTranslation();
   const [scale, setScale] = useState(1);
   const [translate, setTranslate] = useState<Point>({ x: 0, y: 0 });
   const [isDragging, setIsDragging] = useState(false);
@@ -145,7 +147,7 @@ export function ZoomableImage({ src, alt }: { src: string; alt?: string }) {
       <div className="absolute bottom-3 left-1/2 -translate-x-1/2 flex items-center gap-1 bg-black/60 backdrop-blur-sm rounded-full px-1.5 py-1 transition opacity-50 hover:opacity-100">
         <ControlButton
           onClick={zoomOut}
-          label="Zoom out"
+          label={t('zoom_out')}
           disabled={scale <= MIN_SCALE}
         >
           <ZoomOut className="size-3.5" />
@@ -155,7 +157,7 @@ export function ZoomableImage({ src, alt }: { src: string; alt?: string }) {
         </span>
         <ControlButton
           onClick={zoomIn}
-          label="Zoom in"
+          label={t('zoom_in')}
           disabled={scale >= MAX_SCALE}
         >
           <ZoomIn className="size-3.5" />
@@ -163,7 +165,7 @@ export function ZoomableImage({ src, alt }: { src: string; alt?: string }) {
         {isZoomed && (
           <>
             <div className="w-px h-4 bg-white/30 mx-0.5" />
-            <ControlButton onClick={reset} label="Reset zoom">
+            <ControlButton onClick={reset} label={t('reset_zoom')}>
               <RotateCcw className="size-3.5" />
             </ControlButton>
           </>

--- a/packages/react/src/components/__tests__/dialoger-escape.spec.tsx
+++ b/packages/react/src/components/__tests__/dialoger-escape.spec.tsx
@@ -9,6 +9,9 @@ let contentIframe: HTMLIFrameElement;
 
 vi.mock('@opencx/widget-react-headless', () => ({
   useWidget: () => ({ contentIframeRef: { current: contentIframe } }),
+  // DialogerContent translates its dismiss label, and useTranslation reads both.
+  useDocumentDir: () => ({ dir: 'ltr' }),
+  useConfig: () => ({ language: 'en', translationOverrides: undefined }),
 }));
 
 import { DialogerContent, DialogerProvider, useDialoger } from '../Dialoger';


### PR DESCRIPTION
Four spots still held literal English strings, so they ignored `language`
entirely. v5 already covers the composer, this is what was left.

| File | String |
|---|---|
| `Header.tsx` | Close conversation / Are you sure… / No / Yes |
| `Dialoger.tsx` | the modal's screen-reader dismiss label |
| `ZoomableImage.tsx` | Zoom in / Zoom out / Reset zoom |
| `WidgetPopoverContent.tsx` | the panel's `aria-label` |

Nine new keys across all 39 locales. The header button's own `confirmation`
copy still wins over the fallback, so an embedder that already set its own
title/description/buttons sees no change.

`DialogerContent` now calls `useTranslation`, so the Escape-ownership spec's
module mock had to grow `useDocumentDir` and `useConfig` — no assertion changed.

### On the test

`getTranslation` falls back to English when a key is missing, so the existing
"every language defines every key" sweep would stay green for a locale that got
skipped. Added a check that these nine keys actually differ from English in
ar/ja/ru, with a positive control so an empty result means "all translated"
rather than "nothing read". Verified it goes red for the right reason by
setting `ja.dialog_close` to `'Close'` — `expected [ 'dialog_close' ] to deeply
equal []`.

### Checks

- `pnpm type-check` — 4/4 clean
- `pnpm test` — 976 passing across the four packages
- `pnpm lint` still does not run in this repo (`eslint: command not found`); pre-existing

### Not touched

`de.welcome_screen_description` has been garbled on main for a while — it
contains the Dutch `mogelijk` and a mis-accented `Gesprách`. Left alone to keep
this diff to one thing; say the word and I'll send it separately.



<!-- greptile_comment -->

🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎🦎
---

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces remaining hardcoded English accessibility and confirmation labels with typed translations across all supported locales. Risk level: low.
- Adds nine translation keys to the core catalog and every locale.
- Routes dialog, zoom, close-conversation, and panel labels through `useTranslation`.
- Expands regression coverage to detect English fallbacks in every non-English locale.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with a low risk level.

The previously reported Filipino accessibility label is translated, registered, used by the panel, and covered by the all-locale regression test; no blocking failure remains.
</details>

<sub>Reviews (2): Last reviewed commit: ["translate the Filipino panel label and w..."](https://github.com/opencx-labs/widget/commit/a4b7433091a279fd0484fe557898447827eb90f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62261428)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Localization resources](https://app.greptile.com/opencx/-/custom-context/knowledge-base/opencx-labs/widget/-/docs/core-localization.md)
- Knowledge Base — [React widget experience](https://app.greptile.com/opencx/-/custom-context/knowledge-base/opencx-labs/widget/-/docs/react-widget-experience.md)
- Knowledge Base — [Messages, attachments, and feedback UI](https://app.greptile.com/opencx/-/custom-context/knowledge-base/opencx-labs/widget/-/docs/react-message-and-feedback-ui.md)
</details>


<!-- /greptile_comment -->